### PR TITLE
support different blocked entity log

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -200,18 +200,17 @@ public abstract class AbstractAgent {
       " to 5.")
   protected Integer pushBlockedSamples = 5;
 
-  @Parameter(names = {"--blockedPointsLoggerName"}, description = "Logger Name for blocked points")
+  @Parameter(names = {"--blockedPointsLoggerName"}, description = "Logger Name for blocked " +
+      "points. " + "Default: RawBlockedPoints")
   protected String blockedPointsLoggerName = "RawBlockedPoints";
-  protected Logger blockedPointsLogger;
 
   @Parameter(names = {"--blockedHistogramsLoggerName"}, description = "Logger Name for blocked " +
-      "histograms")
+      "histograms" + "Default: RawBlockedPoints")
   protected String blockedHistogramsLoggerName = "RawBlockedPoints";
-  protected Logger blockedHistogramsLogger;
 
-  @Parameter(names = {"--blockedSpansLoggerName"}, description = "Logger Name for blocked spans")
+  @Parameter(names = {"--blockedSpansLoggerName"}, description =
+      "Logger Name for blocked spans" + "Default: RawBlockedPoints")
   protected String blockedSpansLoggerName = "RawBlockedPoints";
-  protected Logger blockedSpansLogger;
 
   @Parameter(names = {"--pushListenerPorts"}, description = "Comma-separated list of ports to listen on. Defaults to " +
       "2878.", order = 4)
@@ -911,11 +910,8 @@ public abstract class AbstractAgent {
           intValue();
       pushBlockedSamples = config.getNumber("pushBlockedSamples", pushBlockedSamples).intValue();
       blockedPointsLoggerName = config.getString("blockedPointsLoggerName", blockedPointsLoggerName);
-      blockedPointsLogger = Logger.getLogger(blockedPointsLoggerName);
       blockedHistogramsLoggerName = config.getString("blockedHistogramsLoggerName", blockedHistogramsLoggerName);
-      blockedHistogramsLogger = Logger.getLogger(blockedHistogramsLoggerName);
       blockedSpansLoggerName = config.getString("blockedSpansLoggerName", blockedSpansLoggerName);
-      blockedSpansLogger = Logger.getLogger(blockedSpansLoggerName);
       pushListenerPorts = config.getString("pushListenerPorts", pushListenerPorts);
       pushListenerMaxReceivedLength = config.getNumber("pushListenerMaxReceivedLength",
           pushListenerMaxReceivedLength).intValue();

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -200,6 +200,19 @@ public abstract class AbstractAgent {
       " to 5.")
   protected Integer pushBlockedSamples = 5;
 
+  @Parameter(names = {"--blockedPointsLoggerName"}, description = "Logger Name for blocked points")
+  protected String blockedPointsLoggerName = "RawBlockedPoints";
+  protected Logger blockedPointsLogger;
+
+  @Parameter(names = {"--blockedHistogramsLoggerName"}, description = "Logger Name for blocked " +
+      "histograms")
+  protected String blockedHistogramsLoggerName = "RawBlockedPoints";
+  protected Logger blockedHistogramsLogger;
+
+  @Parameter(names = {"--blockedSpansLoggerName"}, description = "Logger Name for blocked spans")
+  protected String blockedSpansLoggerName = "RawBlockedPoints";
+  protected Logger blockedSpansLogger;
+
   @Parameter(names = {"--pushListenerPorts"}, description = "Comma-separated list of ports to listen on. Defaults to " +
       "2878.", order = 4)
   protected String pushListenerPorts = "" + GRAPHITE_LISTENING_PORT;
@@ -897,6 +910,12 @@ public abstract class AbstractAgent {
       pushRateLimitMaxBurstSeconds = config.getNumber("pushRateLimitMaxBurstSeconds", pushRateLimitMaxBurstSeconds).
           intValue();
       pushBlockedSamples = config.getNumber("pushBlockedSamples", pushBlockedSamples).intValue();
+      blockedPointsLoggerName = config.getString("blockedPointsLoggerName", blockedPointsLoggerName);
+      blockedPointsLogger = Logger.getLogger(blockedPointsLoggerName);
+      blockedHistogramsLoggerName = config.getString("blockedHistogramsLoggerName", blockedHistogramsLoggerName);
+      blockedHistogramsLogger = Logger.getLogger(blockedHistogramsLoggerName);
+      blockedSpansLoggerName = config.getString("blockedSpansLoggerName", blockedSpansLoggerName);
+      blockedSpansLogger = Logger.getLogger(blockedSpansLoggerName);
       pushListenerPorts = config.getString("pushListenerPorts", pushListenerPorts);
       pushListenerMaxReceivedLength = config.getNumber("pushListenerMaxReceivedLength",
           pushListenerMaxReceivedLength).intValue();

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -153,6 +153,9 @@ public class PushAgent extends AbstractAgent {
           new HistogramDecoder("unknown")),
       ReportableEntityType.TRACE, new SpanDecoder("unknown"),
       ReportableEntityType.TRACE_SPAN_LOGS, new SpanLogsDecoder()));
+  private Logger blockedPointsLogger;
+  private Logger blockedHistogramsLogger;
+  private Logger blockedSpansLogger;
 
   public static void main(String[] args) throws IOException {
     // Start the ssh daemon
@@ -175,6 +178,10 @@ public class PushAgent extends AbstractAgent {
 
   @Override
   protected void startListeners() {
+    blockedPointsLogger = Logger.getLogger(blockedPointsLoggerName);
+    blockedHistogramsLogger = Logger.getLogger(blockedHistogramsLoggerName);
+    blockedSpansLogger = Logger.getLogger(blockedSpansLoggerName);
+
     if (soLingerTime >= 0) {
       childChannelOptions.put(ChannelOption.SO_LINGER, soLingerTime);
     }

--- a/proxy/src/main/java/com/wavefront/agent/handlers/AbstractReportableEntityHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/AbstractReportableEntityHandler.java
@@ -94,9 +94,10 @@ abstract class AbstractReportableEntityHandler<T> implements ReportableEntityHan
                                   @Nullable Collection<SenderTask> senderTasks,
                                   @Nullable Supplier<ValidationConfiguration> validationConfig,
                                   @Nullable String rateUnit,
-                                  boolean setupMetrics) {
+                                  boolean setupMetrics,
+                                  final Logger blockedItemsLogger) {
     this.entityType = entityType;
-    this.blockedItemsLogger = Logger.getLogger("RawBlockedPoints");
+    this.blockedItemsLogger = blockedItemsLogger;
     this.handle = handle;
     this.blockedItemsLimiter = blockedItemsPerBatch == 0 ? null :
         RateLimiter.create(blockedItemsPerBatch / 10d);

--- a/proxy/src/main/java/com/wavefront/agent/handlers/DeltaCounterAccumulationHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/DeltaCounterAccumulationHandlerImpl.java
@@ -70,9 +70,11 @@ public class DeltaCounterAccumulationHandlerImpl extends AbstractReportableEntit
                                                final int blockedItemsPerBatch,
                                                final Collection<SenderTask> senderTasks,
                                                @Nullable final Supplier<ValidationConfiguration> validationConfig,
-                                               long deltaCountersAggregationIntervalSeconds) {
+                                               long deltaCountersAggregationIntervalSeconds,
+                                               final Logger blockedItemLogger) {
         super(ReportableEntityType.DELTA_COUNTER, handle, blockedItemsPerBatch,
-            new ReportPointSerializer(), senderTasks, validationConfig, "pps", true);
+            new ReportPointSerializer(), senderTasks, validationConfig, "pps", true,
+            blockedItemLogger);
 
         this.aggregatedDeltas = Caffeine.newBuilder().
             expireAfterAccess(5 * deltaCountersAggregationIntervalSeconds, TimeUnit.SECONDS).

--- a/proxy/src/main/java/com/wavefront/agent/handlers/HistogramAccumulationHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/HistogramAccumulationHandlerImpl.java
@@ -67,8 +67,10 @@ public class HistogramAccumulationHandlerImpl extends ReportPointHandlerImpl {
       final String handle, final Accumulator digests, final int blockedItemsPerBatch,
       @Nullable Utils.Granularity granularity,
       @Nullable final Supplier<ValidationConfiguration> validationConfig,
-      boolean isHistogramInput) {
-    super(handle, blockedItemsPerBatch, null, validationConfig, isHistogramInput, false);
+      boolean isHistogramInput,
+      final Logger blockedItemLogger) {
+    super(handle, blockedItemsPerBatch, null, validationConfig, isHistogramInput,
+        false, blockedItemLogger);
     this.digests = digests;
     this.granularity = granularity;
     String metricNamespace = "histogram.accumulator." + granularityToString(granularity);

--- a/proxy/src/main/java/com/wavefront/agent/handlers/ReportPointHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/ReportPointHandlerImpl.java
@@ -66,10 +66,11 @@ class ReportPointHandlerImpl extends AbstractReportableEntityHandler<ReportPoint
                          final Collection<SenderTask> senderTasks,
                          @Nullable final Supplier<ValidationConfiguration> validationConfig,
                          final boolean isHistogramHandler,
-                         final boolean setupMetrics) {
+                         final boolean setupMetrics,
+                         final Logger blockedItemLogger) {
     super(isHistogramHandler ? ReportableEntityType.HISTOGRAM : ReportableEntityType.POINT, handle,
         blockedItemsPerBatch, new ReportPointSerializer(), senderTasks, validationConfig,
-        isHistogramHandler ? "dps" : "pps", setupMetrics);
+        isHistogramHandler ? "dps" : "pps", setupMetrics, blockedItemLogger);
     String logPointsProperty = System.getProperty("wavefront.proxy.logpoints");
     this.logPointsFlag = logPointsProperty != null && logPointsProperty.equalsIgnoreCase("true");
     String logPointsSampleRateProperty =

--- a/proxy/src/main/java/com/wavefront/agent/handlers/ReportSourceTagHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/ReportSourceTagHandlerImpl.java
@@ -23,9 +23,11 @@ public class ReportSourceTagHandlerImpl extends AbstractReportableEntityHandler<
       AbstractReportableEntityHandler.class.getCanonicalName());
 
   public ReportSourceTagHandlerImpl(final String handle, final int blockedItemsPerBatch,
-                                    final Collection<SenderTask> senderTasks) {
+                                    final Collection<SenderTask> senderTasks,
+                                    final Logger blockedItemLogger) {
     super(ReportableEntityType.SOURCE_TAG, handle, blockedItemsPerBatch,
-        new ReportSourceTagSerializer(), senderTasks, null, null, true);
+        new ReportSourceTagSerializer(), senderTasks, null, null,
+        true, blockedItemLogger);
   }
 
   @Override

--- a/proxy/src/main/java/com/wavefront/agent/handlers/SpanHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/SpanHandlerImpl.java
@@ -49,9 +49,10 @@ public class SpanHandlerImpl extends AbstractReportableEntityHandler<Span> {
   SpanHandlerImpl(final String handle,
                   final int blockedItemsPerBatch,
                   final Collection<SenderTask> sendDataTasks,
-                  @Nullable final Supplier<ValidationConfiguration> validationConfig) {
+                  @Nullable final Supplier<ValidationConfiguration> validationConfig,
+                  final Logger blockedItemLogger) {
     super(ReportableEntityType.TRACE, handle, blockedItemsPerBatch, new SpanSerializer(),
-        sendDataTasks, validationConfig, "sps", true);
+        sendDataTasks, validationConfig, "sps", true, blockedItemLogger);
 
     String logTracesSampleRateProperty = System.getProperty("wavefront.proxy.logspans.sample-rate");
     this.logSampleRate = NumberUtils.isNumber(logTracesSampleRateProperty) ?

--- a/proxy/src/main/java/com/wavefront/agent/handlers/SpanLogsHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/SpanLogsHandlerImpl.java
@@ -58,9 +58,10 @@ public class SpanLogsHandlerImpl extends AbstractReportableEntityHandler<SpanLog
    */
   SpanLogsHandlerImpl(final String handle,
                       final int blockedItemsPerBatch,
-                      final Collection<SenderTask> sendDataTasks) {
+                      final Collection<SenderTask> sendDataTasks,
+                      final Logger blockedItemLogger) {
     super(ReportableEntityType.TRACE_SPAN_LOGS, handle, blockedItemsPerBatch, SPAN_LOGS_SERIALIZER,
-        sendDataTasks, null, "logs/s", true);
+        sendDataTasks, null, "logs/s", true, blockedItemLogger);
 
     String logTracesSampleRateProperty = System.getProperty("wavefront.proxy.logspans.sample-rate");
     this.logSampleRate = NumberUtils.isNumber(logTracesSampleRateProperty) ?

--- a/proxy/src/main/java/com/wavefront/agent/listeners/JsonMetricsPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/JsonMetricsPortUnificationHandler.java
@@ -50,8 +50,6 @@ import static com.wavefront.agent.channel.ChannelUtils.writeHttpResponse;
  */
 @ChannelHandler.Sharable
 public class JsonMetricsPortUnificationHandler extends AbstractHttpOnlyHandler {
-  private static final Logger logger = Logger.getLogger(JsonMetricsPortUnificationHandler.class.getCanonicalName());
-  private static final Logger blockedPointsLogger = Logger.getLogger("RawBlockedPoints");
   private static final Set<String> STANDARD_PARAMS = ImmutableSet.of("h", "p", "d", "t");
 
   /**

--- a/proxy/src/main/java/com/wavefront/agent/listeners/WriteHttpJsonPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/WriteHttpJsonPortUnificationHandler.java
@@ -46,7 +46,6 @@ import static com.wavefront.agent.channel.ChannelUtils.writeHttpResponse;
 public class WriteHttpJsonPortUnificationHandler extends AbstractHttpOnlyHandler {
   private static final Logger logger = Logger.getLogger(
       WriteHttpJsonPortUnificationHandler.class.getCanonicalName());
-  private static final Logger blockedPointsLogger = Logger.getLogger("RawBlockedPoints");
 
   /**
    * The point handler that takes report metrics one data point at a time and handles batching and retries, etc

--- a/proxy/src/test/java/com/wavefront/agent/handlers/ReportSourceTagHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/handlers/ReportSourceTagHandlerTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 
 import javax.ws.rs.core.Response;
 
@@ -31,6 +32,7 @@ public class ReportSourceTagHandlerTest {
   private SenderTaskFactory senderTaskFactory;
   private ForceQueueEnabledProxyAPI mockAgentAPI;
   private UUID newAgentId;
+  private Logger blockedLogger = Logger.getLogger("RawBlockedPoints");
 
   @Before
   public void setup() {
@@ -39,7 +41,7 @@ public class ReportSourceTagHandlerTest {
     senderTaskFactory = new SenderTaskFactoryImpl(mockAgentAPI, newAgentId, null, new AtomicInteger(100),
         new AtomicInteger(10), new AtomicInteger(1000));
     sourceTagHandler = new ReportSourceTagHandlerImpl("4878", 10, senderTaskFactory.createSenderTasks(
-        HandlerKey.of(ReportableEntityType.SOURCE_TAG, "4878"), 2));
+        HandlerKey.of(ReportableEntityType.SOURCE_TAG, "4878"), 2), blockedLogger);
   }
 
   /**
@@ -76,7 +78,8 @@ public class ReportSourceTagHandlerTest {
     ReportSourceTagSenderTask task2 = EasyMock.createMock(ReportSourceTagSenderTask.class);
     tasks.add(task1);
     tasks.add(task2);
-    ReportSourceTagHandlerImpl sourceTagHandler = new ReportSourceTagHandlerImpl("4878", 10, tasks);
+    ReportSourceTagHandlerImpl sourceTagHandler = new ReportSourceTagHandlerImpl("4878", 10,
+        tasks, blockedLogger);
     task1.add(sourceTag1);
     EasyMock.expectLastCall();
     task1.add(sourceTag2);


### PR DESCRIPTION
test locally on invalid point to 2878, invalid span to 30000, invalid histogram to 40000, non-delta counter to 50000

- different loggers in config.ini, all loggers enabled in log4j2 -> different log files
- no logger in config.ini, all logger enabled in log4j2 -> all in blockedPoints
- span/histogram logger in config,  all loggers enable in log4j2 -> span/histogram log file separate, others go to blockedPoints
- span/histogram logger in config,  corresponding enable in log4j2 -> span/histogram log file only
- No logger in config, no log4j2 -> no log file, console is fine
