### PR TITLE
Remove dumb-init since it is historical and causing an issue for the …

### DIFF
--- a/proxy/docker/Dockerfile
+++ b/proxy/docker/Dockerfile
@@ -15,12 +15,9 @@ RUN apt-get install -y apt-utils
 RUN apt-get install -y curl
 RUN apt-get install -y sudo
 RUN apt-get install -y gnupg2
-RUN apt-get install -y dumb-init
 RUN apt-get install -y debian-archive-keyring
 RUN apt-get install -y apt-transport-https
 RUN apt-get install -y openjdk-8-jdk
-
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # Download wavefront proxy (latest release). Merely extract the debian, don't want to try running startup scripts.
 RUN echo "deb https://packagecloud.io/wavefront/proxy/ubuntu/ bionic main" > /etc/apt/sources.list.d/wavefront_proxy.list


### PR DESCRIPTION
…k8s operator to work with RHEL (requirements to get our stuff certified for openshift).