### PR TITLE
Sanitize span name and tag value for Jaeger/Zipkin; use internal repo…

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -24,13 +24,8 @@
     </dependency>
     <dependency>
       <groupId>com.wavefront</groupId>
-      <artifactId>wavefront-sdk-java</artifactId>
-      <version>1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.wavefront</groupId>
       <artifactId>wavefront-internal-reporter-java</artifactId>
-      <version>0.9.1</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -24,6 +24,11 @@
     </dependency>
     <dependency>
       <groupId>com.wavefront</groupId>
+      <artifactId>wavefront-sdk-java</artifactId>
+      <version>1.15</version>
+    </dependency>
+    <dependency>
+      <groupId>com.wavefront</groupId>
       <artifactId>wavefront-internal-reporter-java</artifactId>
       <version>1.1</version>
     </dependency>

--- a/proxy/src/main/java/com/wavefront/agent/handlers/InternalProxyWavefrontClient.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/InternalProxyWavefrontClient.java
@@ -31,6 +31,7 @@ public class InternalProxyWavefrontClient implements WavefrontSender {
   private final Supplier<ReportableEntityHandler<ReportPoint>> histogramHandlerSupplier;
   private final Supplier<ReportableEntityHandler<Span>> spanHandlerSupplier;
   private final Supplier<ReportableEntityHandler<SpanLogs>> spanLogsHandlerSupplier;
+  private final String clientId;
 
   public InternalProxyWavefrontClient(ReportableEntityHandlerFactory handlerFactory) {
     this(handlerFactory, "internal_client");
@@ -47,6 +48,7 @@ public class InternalProxyWavefrontClient implements WavefrontSender {
         handlerFactory.getHandler(HandlerKey.of(ReportableEntityType.TRACE, handle)));
     this.spanLogsHandlerSupplier = lazySupplier(() ->
         handlerFactory.getHandler(HandlerKey.of(ReportableEntityType.TRACE_SPAN_LOGS, handle)));
+    this.clientId = handle;
   }
 
   @Override
@@ -130,6 +132,11 @@ public class InternalProxyWavefrontClient implements WavefrontSender {
   }
 
   @Override
+  public void sendFormattedMetric(String s) throws IOException {
+    throw new UnsupportedOperationException("Not applicable");
+  }
+
+  @Override
   public void sendSpan(String name, long startMillis, long durationMillis, String source, UUID traceId, UUID spanId,
                        List<UUID> parents, List<UUID> followsFrom, List<Pair<String, String>> tags,
                        @Nullable List<SpanLog> spanLogs) throws IOException {
@@ -139,5 +146,10 @@ public class InternalProxyWavefrontClient implements WavefrontSender {
   @Override
   public void close() throws IOException {
     // noop
+  }
+
+  @Override
+  public String getClientId() {
+    return clientId;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/SpanSanitizeTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/SpanSanitizeTransformer.java
@@ -1,9 +1,10 @@
 package com.wavefront.agent.preprocessor;
 
 import com.google.common.base.Function;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import wavefront.report.Annotation;
 import wavefront.report.Span;
+
+import javax.annotation.Nonnull;
 
 /**
  * Sanitize spans (e.g., span source and tag keys) according to the same rules that are applied at
@@ -18,23 +19,51 @@ public class SpanSanitizeTransformer implements Function<Span, Span> {
     this.ruleMetrics = ruleMetrics;
   }
 
-  @Nullable
   @Override
-  public Span apply(@Nullable Span span) {
+  public Span apply(@Nonnull Span span) {
     long startNanos = ruleMetrics.ruleStart();
     boolean ruleApplied = false;
-    if (!charactersAreValid(span.getSource())) {
-      span.setSource(sanitize(span.getSource()));
-      ruleApplied = true;
+
+    // sanitize name and replace '*' with '-'
+    String name = span.getName();
+    if (name != null) {
+      span.setName(sanitizeValue(name).replace('*', '-'));
+      if (span.getName().equals(name)) {
+        ruleApplied = true;
+      }
     }
+
+    // sanitize source
+    String source = span.getSource();
+    if (source != null) {
+      span.setSource(sanitize(source));
+      if (!ruleApplied && !span.getSource().equals(source)) {
+        ruleApplied = true;
+      }
+    }
+
     if (span.getAnnotations() != null) {
       for (Annotation a : span.getAnnotations()) {
-        if (!charactersAreValid(a.getKey())) {
-          a.setKey(sanitize(a.getKey()));
-          ruleApplied = true;
+        // sanitize tag key
+        String key = a.getKey();
+        if (key != null) {
+          a.setKey(sanitize(key));
+          if (!ruleApplied && !a.getKey().equals(key)) {
+            ruleApplied = true;
+          }
+        }
+
+        // sanitize tag value
+        String value = a.getValue();
+        if (value != null) {
+          a.setValue(sanitizeValue(value));
+          if (!ruleApplied && !a.getValue().equals(value)) {
+            ruleApplied = true;
+          }
         }
       }
     }
+
     if (ruleApplied) {
       ruleMetrics.incrementRuleAppliedCounter();
     }
@@ -42,35 +71,27 @@ public class SpanSanitizeTransformer implements Function<Span, Span> {
     return span;
   }
 
-  private boolean charactersAreValid(String s) {
-    if (s == null) {
-      return true;
-    }
-    for (int i = 0; i < s.length(); i++) {
-      if (!characterIsValid(s.charAt(i))) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private boolean characterIsValid(char c) {
-    // Legal characters are 44-57 (,-./ and numbers), 65-90 (upper), 97-122 (lower), 95 (_)
-    return (44 <= c && c <= 57) || (65 <= c && c <= 90) || (97 <= c && c <= 122) || c == 95;
-  }
-
   /**
    * Sanitize a string so that every invalid character is replaced with a dash.
    */
   private String sanitize(String s) {
-    if (s == null) {
-      return null;
-    }
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < s.length(); i++) {
       char c = s.charAt(i);
-      sb.append(characterIsValid(c) ? c : '-');
+      // Legal characters are 44-57 (,-./ and numbers), 65-90 (upper), 97-122 (lower), 95 (_)
+      if ((44 <= c && c <= 57) || (65 <= c && c <= 90) || (97 <= c && c <= 122) || c == 95) {
+        sb.append(c);
+      } else {
+        sb.append('-');
+      }
     }
     return sb.toString();
+  }
+
+  /**
+   * Remove leading/trailing whitespace and escape newlines.
+   */
+  private String sanitizeValue(String s) {
+    return s.trim().replaceAll("\\n", "\\\\n");
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/SpanSanitizeTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/SpanSanitizeTransformer.java
@@ -6,6 +6,8 @@ import wavefront.report.Span;
 
 import javax.annotation.Nonnull;
 
+import static com.wavefront.sdk.common.Utils.sanitizeWithoutQuotes;
+
 /**
  * Sanitize spans (e.g., span source and tag keys) according to the same rules that are applied at
  * the SDK-level.
@@ -36,7 +38,7 @@ public class SpanSanitizeTransformer implements Function<Span, Span> {
     // sanitize source
     String source = span.getSource();
     if (source != null) {
-      span.setSource(sanitize(source));
+      span.setSource(sanitizeWithoutQuotes(source));
       if (!ruleApplied && !span.getSource().equals(source)) {
         ruleApplied = true;
       }
@@ -47,7 +49,7 @@ public class SpanSanitizeTransformer implements Function<Span, Span> {
         // sanitize tag key
         String key = a.getKey();
         if (key != null) {
-          a.setKey(sanitize(key));
+          a.setKey(sanitizeWithoutQuotes(key));
           if (!ruleApplied && !a.getKey().equals(key)) {
             ruleApplied = true;
           }
@@ -69,24 +71,6 @@ public class SpanSanitizeTransformer implements Function<Span, Span> {
     }
     ruleMetrics.ruleEnd(startNanos);
     return span;
-  }
-
-  /**
-   * Sanitize a string so that every invalid character is replaced with a dash.
-   */
-  private String sanitize(String s) {
-    // TODO: sanitize using SDK instead
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < s.length(); i++) {
-      char c = s.charAt(i);
-      // Legal characters are 44-57 (,-./ and numbers), 65-90 (upper), 97-122 (lower), 95 (_)
-      if ((44 <= c && c <= 57) || (65 <= c && c <= 90) || (97 <= c && c <= 122) || c == 95) {
-        sb.append(c);
-      } else {
-        sb.append('-');
-      }
-    }
-    return sb.toString();
   }
 
   /**

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/SpanSanitizeTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/SpanSanitizeTransformer.java
@@ -75,6 +75,7 @@ public class SpanSanitizeTransformer implements Function<Span, Span> {
    * Sanitize a string so that every invalid character is replaced with a dash.
    */
   private String sanitize(String s) {
+    // TODO: sanitize using SDK instead
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < s.length(); i++) {
       char c = s.charAt(i);
@@ -92,6 +93,7 @@ public class SpanSanitizeTransformer implements Function<Span, Span> {
    * Remove leading/trailing whitespace and escape newlines.
    */
   private String sanitizeValue(String s) {
+    // TODO: sanitize using SDK instead
     return s.trim().replaceAll("\\n", "\\\\n");
   }
 }

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorSpanRulesTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorSpanRulesTest.java
@@ -466,23 +466,24 @@ public class PreprocessorSpanRulesTest {
   public void testSpanSanitizeTransformer() {
     Span span = Span.newBuilder().setCustomer("dummy").setStartMillis(System.currentTimeMillis())
         .setDuration(2345)
-        .setName("HTTP GET ?")
+        .setName(" HTTP GET\"\n? ")
         .setSource("'customJaegerSource'")
         .setSpanId("00000000-0000-0000-0000-00000023cace")
         .setTraceId("00000000-4996-02d2-0000-011f71fb04cb")
         .setAnnotations(ImmutableList.of(
             new Annotation("service", "frontend"),
-            new Annotation("special|tag:", "''")))
+            new Annotation("special|tag:", "''"),
+            new Annotation("specialvalue", " hello \n world ")))
         .build();
     SpanSanitizeTransformer transformer = new SpanSanitizeTransformer(metrics);
     span = transformer.apply(span);
-    assertEquals("HTTP GET ?", span.getName());
+    assertEquals("HTTP GET\"\\n?", span.getName());
     assertEquals("-customJaegerSource-", span.getSource());
     assertEquals(ImmutableList.of("''"),
         span.getAnnotations().stream().filter(x -> x.getKey().equals("special-tag-")).map(Annotation::getValue).
             collect(Collectors.toList()));
-    assertEquals(ImmutableList.of("frontend"),
-        span.getAnnotations().stream().filter(x -> x.getKey().equals("service")).map(Annotation::getValue).
+    assertEquals(ImmutableList.of("hello \\n world"),
+        span.getAnnotations().stream().filter(x -> x.getKey().equals("specialvalue")).map(Annotation::getValue).
             collect(Collectors.toList()));
   }
 


### PR DESCRIPTION
…rter v1.1

Continuation of https://github.com/wavefrontHQ/wavefront-proxy/pull/433/ to make Jaeger/Zipkin span sanitization consistent with SDKs.

- updated span preprocessor rule to sanitize span name and tag values
- replace '*' with '-' in span name
- i don't think quotes need to be escaped in the preprocessor because SpanSerializer will escape them
- derived metrics are sanitized by the internal reporter's sender, so updated to use latest version of the internal reporter