### PR TITLE
Include a device= tag on any relevant time-series

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/DataDogPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/DataDogPortUnificationHandler.java
@@ -302,6 +302,10 @@ public class DataDogPortUnificationHandler extends AbstractHttpOnlyHandler {
         tags.putAll(systemTags);
       }
       extractTags(tagsNode, tags); // tags sent with the data override system host-level tags
+      JsonNode deviceNode = metric.get("device"); // Include a device= tag on the data if that property exists
+      if (deviceNode != null) {
+        tags.put("device", deviceNode.textValue());
+      }
       JsonNode pointsNode = metric.get("points");
       if (pointsNode == null) {
         pointHandler.reject((ReportPoint) null, "Skipping - 'points' field missing.");

--- a/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
@@ -578,6 +578,7 @@ public class PushAgentTest {
         setHost("testhost").
         setTimestamp(1531176936000L).
         setValue(12.052631578947368d).
+        setAnnotations(ImmutableMap.of("device", "eth0")).                    
         build());
     expectLastCall().once();
     replay(mockPointHandler);


### PR DESCRIPTION
Pulls device= as a tag on relevant DataDog metrics.