### PR TITLE
Handle data from DataDog of type:rate

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>net.openhft</groupId>
       <artifactId>chronicle-map</artifactId>
-      <version>3.17.0</version>
+      <version>3.17.8</version>
       <exclusions>
         <exclusion>
           <groupId>com.sun.java</groupId>

--- a/proxy/src/main/java/com/wavefront/agent/listeners/DataDogPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/DataDogPortUnificationHandler.java
@@ -302,6 +302,10 @@ public class DataDogPortUnificationHandler extends AbstractHttpOnlyHandler {
         tags.putAll(systemTags);
       }
       extractTags(tagsNode, tags); // tags sent with the data override system host-level tags
+      JsonNode deviceNode = metric.get("device"); // Include a device= tag on the data if that property exists
+      if (deviceNode != null) {
+        tags.put("device", deviceNode.textValue());
+      }
       JsonNode pointsNode = metric.get("points");
       if (pointsNode == null) {
         pointHandler.reject((ReportPoint) null, "Skipping - 'points' field missing.");

--- a/proxy/src/main/java/com/wavefront/agent/listeners/DataDogPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/DataDogPortUnificationHandler.java
@@ -310,7 +310,10 @@ public class DataDogPortUnificationHandler extends AbstractHttpOnlyHandler {
       JsonNode type = metric.get("type");
       if (type != null) {
         if (type.textValue().equals("rate")) {
-          interval = metric.get("interval") == null ? 1 : metric.get("interval").intValue();
+          JsonNode jsonInterval = metric.get("interval");
+          if (jsonInterval != null && jsonInterval.isNumber()) {
+            interval = jsonInterval.intValue();
+          }
         }
       }
       JsonNode pointsNode = metric.get("points");

--- a/proxy/src/main/java/com/wavefront/agent/listeners/DataDogPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/DataDogPortUnificationHandler.java
@@ -306,6 +306,13 @@ public class DataDogPortUnificationHandler extends AbstractHttpOnlyHandler {
       if (deviceNode != null) {
         tags.put("device", deviceNode.textValue());
       }
+      int interval = 1; // If the metric is of type rate its value needs to be multiplied by the specified interval
+      JsonNode type = metric.get("type");
+      if (type != null) {
+        if (type.textValue().equals("rate")) {
+          interval = metric.get("interval") == null ? 1 : metric.get("interval").intValue();
+        }
+      }
       JsonNode pointsNode = metric.get("points");
       if (pointsNode == null) {
         pointHandler.reject((ReportPoint) null, "Skipping - 'points' field missing.");
@@ -314,7 +321,7 @@ public class DataDogPortUnificationHandler extends AbstractHttpOnlyHandler {
       for (JsonNode node : pointsNode) {
         if (node.size() == 2) {
           reportValue(metricName, hostName, tags, node.get(1), node.get(0).longValue() * 1000,
-              pointCounter);
+              pointCounter, interval);
         } else {
           pointHandler.reject((ReportPoint) null,
               "WF-300: Inconsistent point value size (expected: 2)");
@@ -460,6 +467,11 @@ public class DataDogPortUnificationHandler extends AbstractHttpOnlyHandler {
 
   private void reportValue(String metricName, String hostName, Map<String, String> tags,
                            JsonNode valueNode, long timestamp, AtomicInteger pointCounter) {
+    reportValue(metricName, hostName, tags, valueNode, timestamp, pointCounter, 1);
+  }
+
+  private void reportValue(String metricName, String hostName, Map<String, String> tags,
+                           JsonNode valueNode, long timestamp, AtomicInteger pointCounter, int interval) {
     if (valueNode == null || valueNode.isNull()) return;
     double value;
     if (valueNode.isTextual()) {
@@ -475,6 +487,8 @@ public class DataDogPortUnificationHandler extends AbstractHttpOnlyHandler {
     } else {
       value = valueNode.asLong();
     }
+
+    value = value * interval; // interval will normally be 1 unless the metric was a rate type with a specified interval
 
     ReportPoint point = ReportPoint.newBuilder().
         setTable("dummy").

--- a/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
@@ -581,6 +581,14 @@ public class PushAgentTest {
         setAnnotations(ImmutableMap.of("device", "eth0")).                    
         build());
     expectLastCall().once();
+    mockPointHandler.report(ReportPoint.newBuilder().
+            setTable("dummy").
+            setMetric("test.metric").
+            setHost("testhost").
+            setTimestamp(1531176936000L).
+            setValue(400.0d).
+            build());
+    expectLastCall().once();
     replay(mockPointHandler);
     gzippedHttpPost("http://localhost:" + ddPort + "/api/v1/series", getResource("ddTestTimeseries.json"));
     verify(mockPointHandler);

--- a/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
@@ -578,6 +578,7 @@ public class PushAgentTest {
         setHost("testhost").
         setTimestamp(1531176936000L).
         setValue(12.052631578947368d).
+        setAnnotations(ImmutableMap.of("device", "eth0")).                    
         build());
     expectLastCall().once();
     replay(mockPointHandler);

--- a/proxy/src/test/resources/com.wavefront.agent/ddTestTimeseries.json
+++ b/proxy/src/test/resources/com.wavefront.agent/ddTestTimeseries.json
@@ -37,6 +37,19 @@
       "source_type_name": "System",
       "metric": "system.net.packets_in.count",
       "device": "eth0"
+    },
+    {
+      "metric":"test.metric",
+      "points":[
+        [
+          1531176936,
+          20
+        ]
+      ],
+      "type":"rate",
+      "interval": 20,
+      "host":"testhost",
+      "tags":null
     }
   ]
 }


### PR DESCRIPTION
When DataDog sends statsd counter data the JSON contains a value that when displayed by DataDog is multiplied by the "interval" property supplied in the JSON.

This change allows Wavefront to store and render that same value. The modified value also matches what the telegraf statsd input plugin sends for the same DogStatsD data so this seems to be a quirk of how DataDog sends and parses the data.