### PR TITLE
Cache DD host tags even if no metrics are present

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/DataDogPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/DataDogPortUnificationHandler.java
@@ -302,6 +302,10 @@ public class DataDogPortUnificationHandler extends AbstractHttpOnlyHandler {
         tags.putAll(systemTags);
       }
       extractTags(tagsNode, tags); // tags sent with the data override system host-level tags
+      JsonNode deviceNode = metric.get("device"); // Include a device= tag on the data if that property exists
+      if (deviceNode != null) {
+        tags.put("device", deviceNode.textValue());
+      }
       JsonNode pointsNode = metric.get("points");
       if (pointsNode == null) {
         pointHandler.reject((ReportPoint) null, "Skipping - 'points' field missing.");

--- a/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
@@ -578,6 +578,7 @@ public class PushAgentTest {
         setHost("testhost").
         setTimestamp(1531176936000L).
         setValue(12.052631578947368d).
+        setAnnotations(ImmutableMap.of("device", "eth0")).                    
         build());
     expectLastCall().once();
     replay(mockPointHandler);

--- a/proxy/src/test/resources/com.wavefront.agent/ddTestSystemMetadataOnly.json
+++ b/proxy/src/test/resources/com.wavefront.agent/ddTestSystemMetadataOnly.json
@@ -1,0 +1,9 @@
+{
+  "internalHostname": "testHost",
+  "host-tags": {
+    "system": [
+      "app:closedstack",
+      "role:control"
+    ]
+  }
+}

--- a/proxy/src/test/resources/com.wavefront.agent/ddTestTimeseries.json
+++ b/proxy/src/test/resources/com.wavefront.agent/ddTestTimeseries.json
@@ -23,7 +23,7 @@
         ]
       ],
       "host": "testHost",
-      "tags": ["env:prod,type:test", "source:Launcher"]
+      "tags": ["env:prod,app:openstack", "source:Launcher"]
     },
     {
       "type": "gauge",


### PR DESCRIPTION
We saw a case where "tags" were being supplied in datadog.yaml but were not showing up in Wavefront. It was due to the fact that no "metrics" were being sent in the data sent to the "/intake" endpoint and therefore the host-tags were not being processed. 

This PR ensures that host-tags are always processed if they exist in the data.