### PR TITLE
Updated MetricsMatcher

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/config/MetricMatcher.java
+++ b/proxy/src/main/java/com/wavefront/agent/config/MetricMatcher.java
@@ -182,7 +182,7 @@ public class MetricMatcher extends Configuration {
     for (int i = 0; i < tagKeys.size(); i++) {
       String tagKey = tagKeys.get(i);
       if (tagValues.size() > 0) {
-        String value = expandTemplate(tagValues.get(i), matches));
+        String value = expandTemplate(tagValues.get(i), matches);
         if(value.trim().length() > 0) {
           tags.put(tagKey, value);
         }

--- a/proxy/src/main/java/com/wavefront/agent/config/MetricMatcher.java
+++ b/proxy/src/main/java/com/wavefront/agent/config/MetricMatcher.java
@@ -183,7 +183,7 @@ public class MetricMatcher extends Configuration {
       String tagKey = tagKeys.get(i);
       if (tagValues.size() > 0) {
         String value = expandTemplate(tagValues.get(i), matches);
-        if(value.trim().length() > 0) {
+        if(StringUtils.isNotBlank(value)) {
           tags.put(tagKey, value);
         }
       } else {
@@ -194,7 +194,7 @@ public class MetricMatcher extends Configuration {
           continue;
         }
         String value = (String) matches.get(tagValueLabel);
-        if(value.trim().length() > 0) {
+        if(StringUtils.isNotBlank(value)) {
           tags.put(tagKey, value);
         }
       }

--- a/proxy/src/main/java/com/wavefront/agent/config/MetricMatcher.java
+++ b/proxy/src/main/java/com/wavefront/agent/config/MetricMatcher.java
@@ -182,7 +182,10 @@ public class MetricMatcher extends Configuration {
     for (int i = 0; i < tagKeys.size(); i++) {
       String tagKey = tagKeys.get(i);
       if (tagValues.size() > 0) {
-        tags.put(tagKey, expandTemplate(tagValues.get(i), matches));
+        String value = expandTemplate(tagValues.get(i), matches));
+        if(value.trim().length() > 0) {
+          tags.put(tagKey, value);
+        }
       } else {
         String tagValueLabel = tagValueLabels.get(i);
         if (!matches.containsKey(tagValueLabel)) {
@@ -191,7 +194,9 @@ public class MetricMatcher extends Configuration {
           continue;
         }
         String value = (String) matches.get(tagValueLabel);
-        tags.put(tagKey, value);
+        if(value.trim().length() > 0) {
+          tags.put(tagKey, value);
+        }
       }
     }
     builder.setAnnotations(tags);


### PR DESCRIPTION
1. Prevent log message parsing to contain tags with empty values from being added to the telemetry datum.