### PR TITLE
Exclude span line data when reporting span logs

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import com.wavefront.agent.handlers.ReportableEntityHandler;
 import com.wavefront.agent.preprocessor.ReportableEntityPreprocessor;
 import com.wavefront.common.TraceConstants;
-import com.wavefront.ingester.SpanSerializer;
 import com.wavefront.internal.reporter.WavefrontInternalReporter;
 import com.wavefront.sdk.entities.tracing.sampling.Sampler;
 import com.yammer.metrics.core.Counter;
@@ -61,7 +60,6 @@ public abstract class JaegerThriftUtils {
   private final static Set<String> IGNORE_TAGS = ImmutableSet.of("sampler.type", "sampler.param");
   private final static String FORCE_SAMPLED_KEY = "sampling.priority";
   private static final Logger JAEGER_DATA_LOGGER = Logger.getLogger("JaegerDataLogger");
-  private static final SpanSerializer SPAN_SERIALIZER = new SpanSerializer();
 
   private JaegerThriftUtils() {
   }
@@ -302,7 +300,6 @@ public abstract class JaegerThriftUtils {
                   setFields(fields).
                   build();
             }).collect(Collectors.toList())).
-            setSpan(SPAN_SERIALIZER.apply(wavefrontSpan)).
             build();
         spanLogsHandler.report(spanLogs);
       }

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/TracePortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/TracePortUnificationHandler.java
@@ -260,6 +260,8 @@ public class TracePortUnificationHandler extends AbstractLineDelimitedHandler {
           boolean sampleError = alwaysSampleErrors && span.getAnnotations().stream().anyMatch(t ->
               t.getKey().equals(ERROR_SPAN_TAG_KEY) && t.getValue().equals(ERROR_SPAN_TAG_VAL));
           if (sampleError || samplerFunc.apply(span)) {
+            // after sampling, span line data is no longer needed
+            spanLogs.setSpan(null);
             handler.report(spanLogs);
           }
         }

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java
@@ -16,7 +16,6 @@ import com.wavefront.agent.preprocessor.ReportableEntityPreprocessor;
 import com.wavefront.common.NamedThreadFactory;
 import com.wavefront.common.TraceConstants;
 import com.wavefront.data.ReportableEntityType;
-import com.wavefront.ingester.SpanSerializer;
 import com.wavefront.internal.reporter.WavefrontInternalReporter;
 import com.wavefront.sdk.common.WavefrontSender;
 import com.wavefront.sdk.entities.tracing.sampling.Sampler;
@@ -118,7 +117,6 @@ public class ZipkinPortUnificationHandler extends AbstractHttpOnlyHandler
   private final Set<String> traceDerivedCustomTagKeys;
 
   private static final Logger ZIPKIN_DATA_LOGGER = Logger.getLogger("ZipkinDataLogger");
-  private static final SpanSerializer SPAN_SERIALIZER = new SpanSerializer();
 
   public ZipkinPortUnificationHandler(String handle,
                                       final HealthCheckManager healthCheckManager,
@@ -402,7 +400,6 @@ public class ZipkinPortUnificationHandler extends AbstractHttpOnlyHandler
                     setFields(ImmutableMap.of("annotation", x.value())).
                     build()).
                 collect(Collectors.toList())).
-            setSpan(SPAN_SERIALIZER.apply(wavefrontSpan)).
             build();
         spanLogsHandler.report(spanLogs);
       }

--- a/proxy/src/test/java/com/wavefront/agent/HttpEndToEndTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/HttpEndToEndTest.java
@@ -573,9 +573,7 @@ public class HttpEndToEndTest {
     String expectedSpanLog = "{\"customer\":\"dummy\",\"traceId\":\"" + traceId + "\",\"spanId" +
         "\":\"testspanid\",\"spanSecondaryId\":null,\"logs\":[{\"timestamp\":" + timestamp1 + "," +
         "\"fields\":{\"key\":\"value\",\"key2\":\"value2\"}},{\"timestamp\":" + timestamp2 + "," +
-        "\"fields\":{\"key3\":\"value3\",\"key4\":\"value4\"}}],\"span\":\"" +
-        "testSpanName parent=parent1 source=testsource spanId=testspanid traceId=\\\"" + traceId +
-        "\\\" parent=parent2 " + time + " " + (time + 1) + "\\n\"}";
+        "\"fields\":{\"key3\":\"value3\",\"key4\":\"value4\"}}],\"span\":null}";
     AtomicBoolean gotSpan = new AtomicBoolean(false);
     AtomicBoolean gotSpanLog = new AtomicBoolean(false);
     server.update(req -> {

--- a/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
@@ -613,7 +613,6 @@ public class PushAgentTest {
                 setFields(ImmutableMap.of("key3", "value3", "key4", "value4")).
                 build()
         )).
-        setSpan(spanData).
         build());
     mockTraceHandler.report(Span.newBuilder().setCustomer("dummy").setStartMillis(startTime * 1000)
         .setDuration(1000)
@@ -750,7 +749,6 @@ public class PushAgentTest {
                 setFields(ImmutableMap.of("key3", "value3", "key4", "value4")).
                 build()
         )).
-        setSpan(spanData).
         build());
     expectLastCall();
     mockTraceHandler.report(Span.newBuilder().setCustomer("dummy").setStartMillis(startTime * 1000)
@@ -827,7 +825,6 @@ public class PushAgentTest {
                 setFields(ImmutableMap.of("key3", "value3", "key4", "value4")).
                 build()
         )).
-        setSpan(spanData).
         build());
     expectLastCall();
     mockTraceHandler.report(Span.newBuilder().setCustomer("dummy").setStartMillis(startTime * 1000)
@@ -1344,7 +1341,6 @@ public class PushAgentTest {
                 setFields(ImmutableMap.of("key3", "value3", "key4", "value4")).
                 build()
         )).
-        setSpan(spanData).
         build());
     expectLastCall();
     mockTraceHandler.report(Span.newBuilder().setCustomer("dummy").setStartMillis(startTime * 1000)

--- a/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
@@ -517,7 +517,7 @@ public class PushAgentTest {
     String spanLogDataWithSpanField = "{\"spanId\":\"testspanid\",\"traceId\":\"" + traceId +
         "\",\"logs\":[{\"timestamp\":" + timestamp1 +
         ",\"fields\":{\"key\":\"value\",\"key2\":\"value2\"}},{\"timestamp\":" +
-        timestamp2 + ",\"fields\":{\"key3\":\"value3\",\"key4\":\"value4\"}}]," +
+        timestamp2 + ",\"fields\":{\"key3\":\"value3\"}}]," +
         "\"span\":\"" + escapeSpanData(spanData) + "\"}\n";
     String mixedData = "@SourceTag action=save source=testSource newtag1 newtag2\n" +
         "@Event " + startTime + " \"Event name for testing\" host=host1 host=host2 tag=tag1 " +
@@ -610,7 +610,7 @@ public class PushAgentTest {
                 build(),
             SpanLog.newBuilder().
                 setTimestamp(timestamp2).
-                setFields(ImmutableMap.of("key3", "value3", "key4", "value4")).
+                setFields(ImmutableMap.of("key3", "value3")).
                 build()
         )).
         build());
@@ -1338,9 +1338,10 @@ public class PushAgentTest {
                 build(),
             SpanLog.newBuilder().
                 setTimestamp(timestamp2).
-                setFields(ImmutableMap.of("key3", "value3", "key4", "value4")).
+                setFields(ImmutableMap.of("key3", "value3")).
                 build()
         )).
+        setSpan(spanData).
         build());
     expectLastCall();
     mockTraceHandler.report(Span.newBuilder().setCustomer("dummy").setStartMillis(startTime * 1000)
@@ -1369,7 +1370,7 @@ public class PushAgentTest {
     String spanLogDataWithSpanField = "{\"spanId\":\"testspanid\",\"traceId\":\"" + traceId +
         "\",\"logs\":[{\"timestamp\":" + timestamp1 +
         ",\"fields\":{\"key\":\"value\",\"key2\":\"value2\"}},{\"timestamp\":" +
-        timestamp2 + ",\"fields\":{\"key3\":\"value3\",\"key4\":\"value4\"}}]," +
+        timestamp2 + ",\"fields\":{\"key3\":\"value3\"}}]," +
         "\"span\":\"" + escapeSpanData(spanData) + "\"}\n";
     String badData = "@SourceTag action=save source=testSource newtag1 newtag2\n" +
         "@Event " + startTime + " \"Event name for testing\" host=host1 host=host2 tag=tag1 " +

--- a/proxy/src/test/java/com/wavefront/agent/listeners/tracing/JaegerPortUnificationHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/tracing/JaegerPortUnificationHandlerTest.java
@@ -6,7 +6,6 @@ import com.wavefront.agent.auth.TokenAuthenticatorBuilder;
 import com.wavefront.agent.channel.NoopHealthCheckManager;
 import com.wavefront.agent.handlers.MockReportableEntityHandlerFactory;
 import com.wavefront.agent.handlers.ReportableEntityHandler;
-import com.wavefront.ingester.SpanSerializer;
 import com.wavefront.sdk.entities.tracing.sampling.RateSampler;
 import io.jaegertracing.thriftjava.Batch;
 import io.jaegertracing.thriftjava.Log;
@@ -16,7 +15,11 @@ import io.jaegertracing.thriftjava.TagType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
 import org.apache.thrift.TSerializer;
 import org.easymock.EasyMock;
 import org.junit.Test;
@@ -39,7 +42,6 @@ import static org.easymock.EasyMock.verify;
  */
 public class JaegerPortUnificationHandlerTest {
   private static final String DEFAULT_SOURCE = "jaeger";
-  private static final SpanSerializer SPAN_SERIALIZER = new SpanSerializer();
   private ReportableEntityHandler<Span, String> mockTraceHandler =
       MockReportableEntityHandlerFactory.getMockTraceHandler();
   private ReportableEntityHandler<SpanLogs, String> mockTraceSpanLogsHandler =
@@ -80,7 +82,6 @@ public class JaegerPortUnificationHandlerTest {
                 setFields(ImmutableMap.of("event", "error", "exception", "NullPointerException")).
                 build()
         )).
-        setSpan(SPAN_SERIALIZER.apply(expectedSpan1)).
         build());
     expectLastCall();
 

--- a/proxy/src/test/java/com/wavefront/agent/listeners/tracing/JaegerTChannelCollectorHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/tracing/JaegerTChannelCollectorHandlerTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableMap;
 import com.uber.tchannel.messages.ThriftRequest;
 import com.wavefront.agent.handlers.MockReportableEntityHandlerFactory;
 import com.wavefront.agent.handlers.ReportableEntityHandler;
-import com.wavefront.ingester.SpanSerializer;
 import com.wavefront.sdk.entities.tracing.sampling.DurationSampler;
 import com.wavefront.sdk.entities.tracing.sampling.RateSampler;
 
@@ -30,7 +29,6 @@ import static org.easymock.EasyMock.verify;
 
 public class JaegerTChannelCollectorHandlerTest {
   private static final String DEFAULT_SOURCE = "jaeger";
-  private static final SpanSerializer SPAN_SERIALIZER = new SpanSerializer();
   private ReportableEntityHandler<Span, String> mockTraceHandler =
       MockReportableEntityHandlerFactory.getMockTraceHandler();
   private ReportableEntityHandler<SpanLogs, String> mockTraceLogsHandler =
@@ -69,7 +67,6 @@ public class JaegerTChannelCollectorHandlerTest {
                 setFields(ImmutableMap.of("event", "error", "exception", "NullPointerException")).
                 build()
         )).
-        setSpan(SPAN_SERIALIZER.apply(expectedSpan1)).
         build());
     expectLastCall();
 
@@ -340,7 +337,6 @@ public class JaegerTChannelCollectorHandlerTest {
                 setFields(ImmutableMap.of("event", "error", "exception", "NullPointerException")).
                 build()
         )).
-        setSpan(SPAN_SERIALIZER.apply(expectedSpan2)).
         build());
     expectLastCall();
 
@@ -418,7 +414,6 @@ public class JaegerTChannelCollectorHandlerTest {
                 setFields(ImmutableMap.of("event", "error", "exception", "NullPointerException")).
                 build()
         )).
-        setSpan(SPAN_SERIALIZER.apply(expectedSpan1)).
         build());
     expectLastCall();
 
@@ -451,7 +446,6 @@ public class JaegerTChannelCollectorHandlerTest {
                 setFields(ImmutableMap.of("event", "error", "exception", "NullPointerException")).
                 build()
         )).
-        setSpan(SPAN_SERIALIZER.apply(expectedSpan2)).
         build());
     expectLastCall();
 

--- a/proxy/src/test/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandlerTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableMap;
 import com.wavefront.agent.channel.NoopHealthCheckManager;
 import com.wavefront.agent.handlers.MockReportableEntityHandlerFactory;
 import com.wavefront.agent.handlers.ReportableEntityHandler;
-import com.wavefront.ingester.SpanSerializer;
 import com.wavefront.sdk.entities.tracing.sampling.DurationSampler;
 import com.wavefront.sdk.entities.tracing.sampling.RateSampler;
 
@@ -38,7 +37,6 @@ import static org.easymock.EasyMock.verify;
 
 public class ZipkinPortUnificationHandlerTest {
   private static final String DEFAULT_SOURCE = "zipkin";
-  private static final SpanSerializer SPAN_SERIALIZER = new SpanSerializer();
   private ReportableEntityHandler<Span, String> mockTraceHandler =
       MockReportableEntityHandlerFactory.getMockTraceHandler();
   private ReportableEntityHandler<SpanLogs, String> mockTraceSpanLogsHandler =
@@ -213,7 +211,6 @@ public class ZipkinPortUnificationHandlerTest {
                 setFields(ImmutableMap.of("annotation", "start processing")).
                 build()
             )).
-        setSpan(SPAN_SERIALIZER.apply(span1)).
         build());
     expectLastCall();
 
@@ -228,7 +225,6 @@ public class ZipkinPortUnificationHandlerTest {
                         setFields(ImmutableMap.of("annotation", "start processing")).
                         build()
         )).
-        setSpan(SPAN_SERIALIZER.apply(span2)).
         build());
     expectLastCall();
 
@@ -313,7 +309,6 @@ public class ZipkinPortUnificationHandlerTest {
                 setFields(ImmutableMap.of("annotation", "start processing")).
                 build()
         )).
-        setSpan(SPAN_SERIALIZER.apply(expectedSpan2)).
         build());
     expectLastCall();
     replay(mockTraceHandler, mockTraceSpanLogsHandler);
@@ -376,7 +371,6 @@ public class ZipkinPortUnificationHandlerTest {
                 setFields(ImmutableMap.of("annotation", "start processing")).
                 build()
         )).
-        setSpan(SPAN_SERIALIZER.apply(expectedSpan2)).
         build());
     expectLastCall();
 
@@ -414,7 +408,6 @@ public class ZipkinPortUnificationHandlerTest {
                 setFields(ImmutableMap.of("annotation", "start processing")).
                 build()
         )).
-        setSpan(SPAN_SERIALIZER.apply(expectedSpan3)).
         build());
     expectLastCall();
 


### PR DESCRIPTION
No need to sample a second time in the backend.