### PR TITLE
version lock ffi to fix fpm installation

### DIFF
--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -L get.rvm.io | bash -s stable
 ENV PATH /usr/local/rvm/gems/ruby-2.0.0-p598/bin:/usr/local/rvm/gems/ruby-2.0.0-p598@global/bin:/usr/local/rvm/rubies/ruby-2.0.0-p598/bin:/usr/local/rvm/bin:$PATH
 ENV LC_ALL en_US.UTF-8
 RUN rvm install 2.0.0-p598
-RUN gem install childprocess:1.0.1 fpm:1.10.0 package_cloud:0.2.35
+RUN gem install ffi:1.12.2 childprocess:1.0.1 fpm:1.10.0 package_cloud:0.2.35
 
 # Wavefront software. This repo contains build scripts for the agent, to be run
 # inside this container.


### PR DESCRIPTION
docker build for pkg/Dockerfile is failing with following error:
```
[91mERROR:  Error installing fpm:
	The last version of ffi (>= 0) to support your Ruby & RubyGems was 1.12.2. Try installing it with `gem install ffi -v 1.12.2` and then running the current command again
	ffi requires Ruby version >= 2.3. The current ruby version is 2.0.0.598.
```