### PR TITLE
Report derived metrics with updated values post span is transformed with preprocessor rules.

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/CustomTracingPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/CustomTracingPortUnificationHandler.java
@@ -124,6 +124,7 @@ public class CustomTracingPortUnificationHandler extends TracePortUnificationHan
           continue;
         case SERVICE_TAG_KEY:
           serviceName = annotation.getValue();
+          continue;
         case CLUSTER_TAG_KEY:
           cluster = annotation.getValue();
           continue;
@@ -132,10 +133,10 @@ public class CustomTracingPortUnificationHandler extends TracePortUnificationHan
           continue;
         case COMPONENT_TAG_KEY:
           componentTagValue = annotation.getValue();
-          break;
+          continue;
         case ERROR_SPAN_TAG_KEY:
           isError = annotation.getValue();
-          break;
+          continue;
       }
     }
     if (applicationName.equals(NULL_TAG_VAL) || serviceName.equals(NULL_TAG_VAL)) {

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
@@ -314,11 +314,37 @@ public abstract class JaegerThriftUtils {
         spanLogsHandler.report(spanLogs);
       }
     }
+
     // report stats irrespective of span sampling.
     if (wfInternalReporter != null) {
-      // report converted metrics/histograms from the span
-      List<Pair<String, String>> spanTags = annotations.stream().map(a -> new Pair<>(a.getKey(),
-          a.getValue())).collect(Collectors.toList());
+      // Set post preprocessor rule values and report converted metrics/histograms from the span
+      sourceName = wavefrontSpan.getSource();
+      List<Annotation> processedAnnotations = wavefrontSpan.getAnnotations();
+      for (Annotation processedAnnotation : processedAnnotations) {
+        switch (processedAnnotation.getKey()) {
+          case APPLICATION_TAG_KEY:
+            applicationName = processedAnnotation.getValue();
+            continue;
+          case SERVICE_TAG_KEY:
+            serviceName = processedAnnotation.getValue();
+            continue;
+          case CLUSTER_TAG_KEY:
+            cluster = processedAnnotation.getValue();
+            continue;
+          case SHARD_TAG_KEY:
+            shard = processedAnnotation.getValue();
+            continue;
+          case COMPONENT_TAG_KEY:
+            componentTagValue = processedAnnotation.getValue();
+            continue;
+          case ERROR_SPAN_TAG_KEY:
+            isError = processedAnnotation.getValue().equals(ERROR_SPAN_TAG_VAL);
+            continue;
+        }
+      }
+      List<Pair<String, String>> spanTags = processedAnnotations.stream().map(
+          a -> new Pair<>(a.getKey(), a.getValue())).collect(Collectors.toList());
+      // TODO: Modify to use new method from wavefront internal reporter.
       discoveredHeartbeatMetrics.add(reportWavefrontGeneratedData(wfInternalReporter,
           span.getOperationName(), applicationName, serviceName, cluster, shard, sourceName,
           componentTagValue, isError, span.getDuration(), traceDerivedCustomTagKeys,


### PR DESCRIPTION
Also fixed bug in CustomTracingPortHandler , where CLUSTER_TAG_KEY is wrongly assigned value of service key.