### PR TITLE
Uber sps ingestmetric

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/RelayPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/RelayPortUnificationHandler.java
@@ -86,6 +86,7 @@ public class RelayPortUnificationHandler extends AbstractHttpOnlyHandler {
   private final Supplier<Counter> discardedHistograms;
   private final Supplier<Counter> discardedSpans;
   private final Supplier<Counter> discardedSpanLogs;
+  private final Supplier<Counter> spansSentToProxy;
 
   /**
    * Create new instance with lazy initialization for handlers.
@@ -122,6 +123,8 @@ public class RelayPortUnificationHandler extends AbstractHttpOnlyHandler {
         ReportableEntityType.TRACE, handle)));
     this.spanLogsHandlerSupplier = Utils.lazySupplier(() -> handlerFactory.getHandler(HandlerKey.of(
         ReportableEntityType.TRACE_SPAN_LOGS, handle)));
+    this.spansSentToProxy = Utils.lazySupplier(() -> Metrics.newCounter(new MetricName(
+        "spans." + handle, "", "sent.count")));
     this.preprocessorSupplier = preprocessorSupplier;
     this.annotator = annotator;
     this.histogramDisabled = histogramDisabled;
@@ -224,6 +227,7 @@ public class RelayPortUnificationHandler extends AbstractHttpOnlyHandler {
       case Constants.PUSH_FORMAT_TRACING:
         if (isFeatureDisabled(traceDisabled, SPAN_DISABLED, discardedSpans.get(), output,
             request)) {
+          spansSentToProxy.get().inc(discardedSpans.get().count());
           status = HttpResponseStatus.FORBIDDEN;
           break;
         }
@@ -236,6 +240,7 @@ public class RelayPortUnificationHandler extends AbstractHttpOnlyHandler {
         Splitter.on('\n').trimResults().omitEmptyStrings().
             split(request.content().toString(CharsetUtil.UTF_8)).forEach(line -> {
           try {
+            spansSentToProxy.get().inc();
             spanDecoder.decode(line, spans, "dummy");
           } catch (Exception e) {
             spanHandler.reject(line, formatErrorMessage(line, e, ctx));

--- a/proxy/src/main/java/com/wavefront/agent/listeners/RelayPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/RelayPortUnificationHandler.java
@@ -86,7 +86,7 @@ public class RelayPortUnificationHandler extends AbstractHttpOnlyHandler {
   private final Supplier<Counter> discardedHistograms;
   private final Supplier<Counter> discardedSpans;
   private final Supplier<Counter> discardedSpanLogs;
-  private final Supplier<Counter> spansSentToProxy;
+  private final Supplier<Counter> receivedSpansTotal;
 
   /**
    * Create new instance with lazy initialization for handlers.
@@ -123,8 +123,8 @@ public class RelayPortUnificationHandler extends AbstractHttpOnlyHandler {
         ReportableEntityType.TRACE, handle)));
     this.spanLogsHandlerSupplier = Utils.lazySupplier(() -> handlerFactory.getHandler(HandlerKey.of(
         ReportableEntityType.TRACE_SPAN_LOGS, handle)));
-    this.spansSentToProxy = Utils.lazySupplier(() -> Metrics.newCounter(new MetricName(
-        "spans." + handle, "", "sent.count")));
+    this.receivedSpansTotal = Utils.lazySupplier(() -> Metrics.newCounter(new MetricName(
+        "spans." + handle, "", "received.total")));
     this.preprocessorSupplier = preprocessorSupplier;
     this.annotator = annotator;
     this.histogramDisabled = histogramDisabled;
@@ -227,7 +227,7 @@ public class RelayPortUnificationHandler extends AbstractHttpOnlyHandler {
       case Constants.PUSH_FORMAT_TRACING:
         if (isFeatureDisabled(traceDisabled, SPAN_DISABLED, discardedSpans.get(), output,
             request)) {
-          spansSentToProxy.get().inc(discardedSpans.get().count());
+          receivedSpansTotal.get().inc(discardedSpans.get().count());
           status = HttpResponseStatus.FORBIDDEN;
           break;
         }
@@ -240,7 +240,7 @@ public class RelayPortUnificationHandler extends AbstractHttpOnlyHandler {
         Splitter.on('\n').trimResults().omitEmptyStrings().
             split(request.content().toString(CharsetUtil.UTF_8)).forEach(line -> {
           try {
-            spansSentToProxy.get().inc();
+            receivedSpansTotal.get().inc();
             spanDecoder.decode(line, spans, "dummy");
           } catch (Exception e) {
             spanHandler.reject(line, formatErrorMessage(line, e, ctx));

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerGrpcCollectorHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerGrpcCollectorHandler.java
@@ -70,7 +70,7 @@ public class JaegerGrpcCollectorHandler extends CollectorServiceGrpc.CollectorSe
   private final String proxyLevelApplicationName;
   private final Set<String> traceDerivedCustomTagKeys;
 
-  private final Counter spansSentToProxy;
+  private final Counter receivedSpansTotal;
   private final Counter discardedTraces;
   private final Counter discardedBatches;
   private final Counter processedBatches;
@@ -124,8 +124,8 @@ public class JaegerGrpcCollectorHandler extends CollectorServiceGrpc.CollectorSe
         new MetricName("spans." + handle + ".batches", "", "failed"));
     this.discardedSpansBySampler = Metrics.newCounter(
         new MetricName("spans." + handle, "", "sampler.discarded"));
-    this.spansSentToProxy = Metrics.newCounter(new MetricName(
-        "spans." + handle, "", "sent.count"));
+    this.receivedSpansTotal = Metrics.newCounter(new MetricName(
+        "spans." + handle, "", "received.total"));
     this.discoveredHeartbeatMetrics = Sets.newConcurrentHashSet();
     this.scheduledExecutorService = Executors.newScheduledThreadPool(1,
         new NamedThreadFactory("jaeger-heart-beater"));
@@ -149,7 +149,7 @@ public class JaegerGrpcCollectorHandler extends CollectorServiceGrpc.CollectorSe
       processBatch(request.getBatch(), null, DEFAULT_SOURCE, proxyLevelApplicationName,
           spanHandler, spanLogsHandler, wfInternalReporter, traceDisabled, spanLogsDisabled,
           preprocessorSupplier, sampler, traceDerivedCustomTagKeys, discardedTraces,
-          discardedBatches, discardedSpansBySampler, discoveredHeartbeatMetrics, spansSentToProxy);
+          discardedBatches, discardedSpansBySampler, discoveredHeartbeatMetrics, receivedSpansTotal);
       processedBatches.inc();
     } catch (Exception e) {
       failedBatches.inc();

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerGrpcCollectorHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerGrpcCollectorHandler.java
@@ -70,6 +70,7 @@ public class JaegerGrpcCollectorHandler extends CollectorServiceGrpc.CollectorSe
   private final String proxyLevelApplicationName;
   private final Set<String> traceDerivedCustomTagKeys;
 
+  private final Counter spansSentToProxy;
   private final Counter discardedTraces;
   private final Counter discardedBatches;
   private final Counter processedBatches;
@@ -123,6 +124,8 @@ public class JaegerGrpcCollectorHandler extends CollectorServiceGrpc.CollectorSe
         new MetricName("spans." + handle + ".batches", "", "failed"));
     this.discardedSpansBySampler = Metrics.newCounter(
         new MetricName("spans." + handle, "", "sampler.discarded"));
+    this.spansSentToProxy = Metrics.newCounter(new MetricName(
+        "spans." + handle, "", "sent.count"));
     this.discoveredHeartbeatMetrics = Sets.newConcurrentHashSet();
     this.scheduledExecutorService = Executors.newScheduledThreadPool(1,
         new NamedThreadFactory("jaeger-heart-beater"));
@@ -146,7 +149,7 @@ public class JaegerGrpcCollectorHandler extends CollectorServiceGrpc.CollectorSe
       processBatch(request.getBatch(), null, DEFAULT_SOURCE, proxyLevelApplicationName,
           spanHandler, spanLogsHandler, wfInternalReporter, traceDisabled, spanLogsDisabled,
           preprocessorSupplier, sampler, traceDerivedCustomTagKeys, discardedTraces,
-          discardedBatches, discardedSpansBySampler, discoveredHeartbeatMetrics);
+          discardedBatches, discardedSpansBySampler, discoveredHeartbeatMetrics, spansSentToProxy);
       processedBatches.inc();
     } catch (Exception e) {
       failedBatches.inc();

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerPortUnificationHandler.java
@@ -79,7 +79,7 @@ public class JaegerPortUnificationHandler extends AbstractHttpOnlyHandler implem
   private final String proxyLevelApplicationName;
   private final Set<String> traceDerivedCustomTagKeys;
 
-  private final Counter spansSentToProxy;
+  private final Counter receivedSpansTotal;
   private final Counter discardedTraces;
   private final Counter discardedBatches;
   private final Counter processedBatches;
@@ -143,8 +143,8 @@ public class JaegerPortUnificationHandler extends AbstractHttpOnlyHandler implem
         new MetricName("spans." + handle + ".batches", "", "failed"));
     this.discardedSpansBySampler = Metrics.newCounter(
         new MetricName("spans." + handle, "", "sampler.discarded"));
-    this.spansSentToProxy = Metrics.newCounter(new MetricName(
-        "spans." + handle, "", "sent.count"));
+    this.receivedSpansTotal = Metrics.newCounter(new MetricName(
+        "spans." + handle, "", "received.total"));
     this.discoveredHeartbeatMetrics = Sets.newConcurrentHashSet();
     this.scheduledExecutorService = Executors.newScheduledThreadPool(1,
         new NamedThreadFactory("jaeger-heart-beater"));
@@ -193,7 +193,7 @@ public class JaegerPortUnificationHandler extends AbstractHttpOnlyHandler implem
           spanLogsHandler, wfInternalReporter, traceDisabled, spanLogsDisabled,
           preprocessorSupplier, sampler, traceDerivedCustomTagKeys,
           discardedTraces, discardedBatches, discardedSpansBySampler, discoveredHeartbeatMetrics,
-          spansSentToProxy);
+          receivedSpansTotal);
       status = HttpResponseStatus.ACCEPTED;
       processedBatches.inc();
     } catch (Exception e) {

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerPortUnificationHandler.java
@@ -79,6 +79,7 @@ public class JaegerPortUnificationHandler extends AbstractHttpOnlyHandler implem
   private final String proxyLevelApplicationName;
   private final Set<String> traceDerivedCustomTagKeys;
 
+  private final Counter spansSentToProxy;
   private final Counter discardedTraces;
   private final Counter discardedBatches;
   private final Counter processedBatches;
@@ -142,6 +143,8 @@ public class JaegerPortUnificationHandler extends AbstractHttpOnlyHandler implem
         new MetricName("spans." + handle + ".batches", "", "failed"));
     this.discardedSpansBySampler = Metrics.newCounter(
         new MetricName("spans." + handle, "", "sampler.discarded"));
+    this.spansSentToProxy = Metrics.newCounter(new MetricName(
+        "spans." + handle, "", "sent.count"));
     this.discoveredHeartbeatMetrics = Sets.newConcurrentHashSet();
     this.scheduledExecutorService = Executors.newScheduledThreadPool(1,
         new NamedThreadFactory("jaeger-heart-beater"));
@@ -189,7 +192,8 @@ public class JaegerPortUnificationHandler extends AbstractHttpOnlyHandler implem
       processBatch(batch, output, DEFAULT_SOURCE, proxyLevelApplicationName, spanHandler,
           spanLogsHandler, wfInternalReporter, traceDisabled, spanLogsDisabled,
           preprocessorSupplier, sampler, traceDerivedCustomTagKeys,
-          discardedTraces, discardedBatches, discardedSpansBySampler, discoveredHeartbeatMetrics);
+          discardedTraces, discardedBatches, discardedSpansBySampler, discoveredHeartbeatMetrics,
+          spansSentToProxy);
       status = HttpResponseStatus.ACCEPTED;
       processedBatches.inc();
     } catch (Exception e) {

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerProtobufUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerProtobufUtils.java
@@ -90,7 +90,7 @@ public abstract class JaegerProtobufUtils {
                                   Counter discardedBatches,
                                   Counter discardedSpansBySampler,
                                   Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics,
-                                  Counter spansSentToProxy) {
+                                  Counter receivedSpansTotal) {
     String serviceName = batch.getProcess().getServiceName();
     List<Annotation> processAnnotations = new ArrayList<>();
     boolean isSourceProcessTagPresent = false;
@@ -125,10 +125,10 @@ public abstract class JaegerProtobufUtils {
     }
     if (isFeatureDisabled(traceDisabled, SPAN_DISABLED, discardedBatches, output)) {
       discardedTraces.inc(batch.getSpansCount());
-      spansSentToProxy.inc(batch.getSpansCount());
+      receivedSpansTotal.inc(batch.getSpansCount());
       return;
     }
-    spansSentToProxy.inc(batch.getSpansCount());
+    receivedSpansTotal.inc(batch.getSpansCount());
     for (Model.Span span : batch.getSpansList()) {
       processSpan(span, serviceName, sourceName, applicationName, processAnnotations,
           spanHandler, spanLogsHandler, wfInternalReporter, spanLogsDisabled,

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerProtobufUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerProtobufUtils.java
@@ -89,7 +89,8 @@ public abstract class JaegerProtobufUtils {
                                   Counter discardedTraces,
                                   Counter discardedBatches,
                                   Counter discardedSpansBySampler,
-                                  Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics) {
+                                  Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics,
+                                  Counter spansSentToProxy) {
     String serviceName = batch.getProcess().getServiceName();
     List<Annotation> processAnnotations = new ArrayList<>();
     boolean isSourceProcessTagPresent = false;
@@ -124,8 +125,10 @@ public abstract class JaegerProtobufUtils {
     }
     if (isFeatureDisabled(traceDisabled, SPAN_DISABLED, discardedBatches, output)) {
       discardedTraces.inc(batch.getSpansCount());
+      spansSentToProxy.inc(batch.getSpansCount());
       return;
     }
+    spansSentToProxy.inc(batch.getSpansCount());
     for (Model.Span span : batch.getSpansList()) {
       processSpan(span, serviceName, sourceName, applicationName, processAnnotations,
           spanHandler, spanLogsHandler, wfInternalReporter, spanLogsDisabled,

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerTChannelCollectorHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerTChannelCollectorHandler.java
@@ -72,7 +72,7 @@ public class JaegerTChannelCollectorHandler extends ThriftRequestHandler<Collect
   private final String proxyLevelApplicationName;
   private final Set<String> traceDerivedCustomTagKeys;
 
-  private final Counter spansSentToProxy;
+  private final Counter receivedSpansTotal;
   private final Counter discardedTraces;
   private final Counter discardedBatches;
   private final Counter processedBatches;
@@ -126,8 +126,8 @@ public class JaegerTChannelCollectorHandler extends ThriftRequestHandler<Collect
         new MetricName("spans." + handle + ".batches", "", "failed"));
     this.discardedSpansBySampler = Metrics.newCounter(
         new MetricName("spans." + handle, "", "sampler.discarded"));
-    this.spansSentToProxy = Metrics.newCounter(new MetricName(
-        "spans." + handle, "", "sent.count"));
+    this.receivedSpansTotal = Metrics.newCounter(new MetricName(
+        "spans." + handle, "", "received.total"));
     this.discoveredHeartbeatMetrics = Sets.newConcurrentHashSet();
     this.scheduledExecutorService = Executors.newScheduledThreadPool(1,
         new NamedThreadFactory("jaeger-heart-beater"));
@@ -153,7 +153,7 @@ public class JaegerTChannelCollectorHandler extends ThriftRequestHandler<Collect
             spanLogsHandler, wfInternalReporter, traceDisabled, spanLogsDisabled,
             preprocessorSupplier, sampler, traceDerivedCustomTagKeys, discardedTraces,
             discardedBatches, discardedSpansBySampler, discoveredHeartbeatMetrics,
-            spansSentToProxy);
+            receivedSpansTotal);
         processedBatches.inc();
       } catch (Exception e) {
         failedBatches.inc();

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerTChannelCollectorHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerTChannelCollectorHandler.java
@@ -72,6 +72,7 @@ public class JaegerTChannelCollectorHandler extends ThriftRequestHandler<Collect
   private final String proxyLevelApplicationName;
   private final Set<String> traceDerivedCustomTagKeys;
 
+  private final Counter spansSentToProxy;
   private final Counter discardedTraces;
   private final Counter discardedBatches;
   private final Counter processedBatches;
@@ -125,6 +126,8 @@ public class JaegerTChannelCollectorHandler extends ThriftRequestHandler<Collect
         new MetricName("spans." + handle + ".batches", "", "failed"));
     this.discardedSpansBySampler = Metrics.newCounter(
         new MetricName("spans." + handle, "", "sampler.discarded"));
+    this.spansSentToProxy = Metrics.newCounter(new MetricName(
+        "spans." + handle, "", "sent.count"));
     this.discoveredHeartbeatMetrics = Sets.newConcurrentHashSet();
     this.scheduledExecutorService = Executors.newScheduledThreadPool(1,
         new NamedThreadFactory("jaeger-heart-beater"));
@@ -149,7 +152,8 @@ public class JaegerTChannelCollectorHandler extends ThriftRequestHandler<Collect
         processBatch(batch, null, DEFAULT_SOURCE, proxyLevelApplicationName, spanHandler,
             spanLogsHandler, wfInternalReporter, traceDisabled, spanLogsDisabled,
             preprocessorSupplier, sampler, traceDerivedCustomTagKeys, discardedTraces,
-            discardedBatches, discardedSpansBySampler, discoveredHeartbeatMetrics);
+            discardedBatches, discardedSpansBySampler, discoveredHeartbeatMetrics,
+            spansSentToProxy);
         processedBatches.inc();
       } catch (Exception e) {
         failedBatches.inc();

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
@@ -84,7 +84,8 @@ public abstract class JaegerThriftUtils {
                                   Counter discardedTraces,
                                   Counter discardedBatches,
                                   Counter discardedSpansBySampler,
-                                  Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics) {
+                                  Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics,
+                                  Counter spansSentToProxy) {
     String serviceName = batch.getProcess().getServiceName();
     List<Annotation> processAnnotations = new ArrayList<>();
     boolean isSourceProcessTagPresent = false;
@@ -119,8 +120,10 @@ public abstract class JaegerThriftUtils {
     }
     if (isFeatureDisabled(traceDisabled, SPAN_DISABLED, discardedBatches, output)) {
       discardedTraces.inc(batch.getSpansSize());
+      spansSentToProxy.inc(batch.getSpansSize());
       return;
     }
+    spansSentToProxy.inc(batch.getSpansSize());
     for (io.jaegertracing.thriftjava.Span span : batch.getSpans()) {
       processSpan(span, serviceName, sourceName, applicationName, processAnnotations,
           spanHandler, spanLogsHandler, wfInternalReporter, spanLogsDisabled,

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
@@ -85,7 +85,7 @@ public abstract class JaegerThriftUtils {
                                   Counter discardedBatches,
                                   Counter discardedSpansBySampler,
                                   Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics,
-                                  Counter spansSentToProxy) {
+                                  Counter receivedSpansTotal) {
     String serviceName = batch.getProcess().getServiceName();
     List<Annotation> processAnnotations = new ArrayList<>();
     boolean isSourceProcessTagPresent = false;
@@ -120,10 +120,10 @@ public abstract class JaegerThriftUtils {
     }
     if (isFeatureDisabled(traceDisabled, SPAN_DISABLED, discardedBatches, output)) {
       discardedTraces.inc(batch.getSpansSize());
-      spansSentToProxy.inc(batch.getSpansSize());
+      receivedSpansTotal.inc(batch.getSpansSize());
       return;
     }
-    spansSentToProxy.inc(batch.getSpansSize());
+    receivedSpansTotal.inc(batch.getSpansSize());
     for (io.jaegertracing.thriftjava.Span span : batch.getSpans()) {
       processSpan(span, serviceName, sourceName, applicationName, processAnnotations,
           spanHandler, spanLogsHandler, wfInternalReporter, spanLogsDisabled,

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/TracePortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/TracePortUnificationHandler.java
@@ -48,7 +48,6 @@ import static com.wavefront.agent.channel.ChannelUtils.formatErrorMessage;
 import static com.wavefront.agent.listeners.FeatureCheckUtils.SPANLOGS_DISABLED;
 import static com.wavefront.agent.listeners.FeatureCheckUtils.SPAN_DISABLED;
 import static com.wavefront.agent.listeners.FeatureCheckUtils.isFeatureDisabled;
-import static com.wavefront.internal.SpanDerivedMetricsUtils.DEBUG_SPAN_TAG_VAL;
 
 /**
  * Process incoming trace-formatted data.
@@ -79,7 +78,7 @@ public class TracePortUnificationHandler extends AbstractLineDelimitedHandler {
   protected final Counter discardedSpanLogs;
   private final Counter discardedSpansBySampler;
   private final Counter discardedSpanLogsBySampler;
-  private final Counter spansSentToProxy;
+  private final Counter receivedSpansTotal;
 
 
   public TracePortUnificationHandler(
@@ -123,7 +122,7 @@ public class TracePortUnificationHandler extends AbstractLineDelimitedHandler {
         "sampler.discarded"));
     this.discardedSpanLogsBySampler = Metrics.newCounter(new MetricName("spanLogs." + handle, "",
         "sampler.discarded"));
-    this.spansSentToProxy = Metrics.newCounter(new MetricName("spans." + handle, "", "sent.count"));
+    this.receivedSpansTotal = Metrics.newCounter(new MetricName("spans." + handle, "", "received.total"));
   }
 
   @Nullable
@@ -145,7 +144,7 @@ public class TracePortUnificationHandler extends AbstractLineDelimitedHandler {
     }
 
     // Payload is a span.
-    spansSentToProxy.inc();
+    receivedSpansTotal.inc();
     if (isFeatureDisabled(traceDisabled, SPAN_DISABLED, discardedSpans)) return;
     preprocessAndHandleSpan(message, decoder, handler, this::report, preprocessorSupplier, ctx,
         span -> sampler.sample(span, discardedSpansBySampler));

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/TracePortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/TracePortUnificationHandler.java
@@ -79,6 +79,8 @@ public class TracePortUnificationHandler extends AbstractLineDelimitedHandler {
   protected final Counter discardedSpanLogs;
   private final Counter discardedSpansBySampler;
   private final Counter discardedSpanLogsBySampler;
+  private final Counter spansSentToProxy;
+
 
   public TracePortUnificationHandler(
       final String handle, final TokenAuthenticator tokenAuthenticator,
@@ -121,6 +123,7 @@ public class TracePortUnificationHandler extends AbstractLineDelimitedHandler {
         "sampler.discarded"));
     this.discardedSpanLogsBySampler = Metrics.newCounter(new MetricName("spanLogs." + handle, "",
         "sampler.discarded"));
+    this.spansSentToProxy = Metrics.newCounter(new MetricName("spans." + handle, "", "sent.count"));
   }
 
   @Nullable
@@ -140,6 +143,9 @@ public class TracePortUnificationHandler extends AbstractLineDelimitedHandler {
           ctx, span -> sampler.sample(span, discardedSpanLogsBySampler));
       return;
     }
+
+    // Payload is a span.
+    spansSentToProxy.inc();
     if (isFeatureDisabled(traceDisabled, SPAN_DISABLED, discardedSpans)) return;
     preprocessAndHandleSpan(message, decoder, handler, this::report, preprocessorSupplier, ctx,
         span -> sampler.sample(span, discardedSpansBySampler));

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java
@@ -103,7 +103,7 @@ public class ZipkinPortUnificationHandler extends AbstractHttpOnlyHandler
   private final Counter processedBatches;
   private final Counter failedBatches;
   private final Counter discardedSpansBySampler;
-  private final Counter spansSentToProxy;
+  private final Counter receivedSpansTotal;
   private final Counter discardedTraces;
   private final Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics;
   private final ScheduledExecutorService scheduledExecutorService;
@@ -168,8 +168,8 @@ public class ZipkinPortUnificationHandler extends AbstractHttpOnlyHandler
         "spans." + handle + ".batches", "", "failed"));
     this.discardedSpansBySampler = Metrics.newCounter(new MetricName(
         "spans." + handle, "", "sampler.discarded"));
-    this.spansSentToProxy = Metrics.newCounter(new MetricName(
-        "spans." + handle, "", "sent.count"));
+    this.receivedSpansTotal = Metrics.newCounter(new MetricName(
+        "spans." + handle, "", "received.total"));
     this.discardedTraces = Metrics.newCounter(
         new MetricName("spans." + handle, "", "discarded"));
     this.discoveredHeartbeatMetrics = Sets.newConcurrentHashSet();
@@ -222,11 +222,11 @@ public class ZipkinPortUnificationHandler extends AbstractHttpOnlyHandler
         status = HttpResponseStatus.ACCEPTED;
         writeHttpResponse(ctx, status, output, request);
         discardedTraces.inc(zipkinSpanSink.size());
-        spansSentToProxy.inc(zipkinSpanSink.size());
+        receivedSpansTotal.inc(zipkinSpanSink.size());
         processedBatches.inc();
         return;
       }
-      spansSentToProxy.inc(zipkinSpanSink.size());
+      receivedSpansTotal.inc(zipkinSpanSink.size());
       processZipkinSpans(zipkinSpanSink);
       status = HttpResponseStatus.ACCEPTED;
       processedBatches.inc();


### PR DESCRIPTION
Add raw span ingest metric. (~proxy.spans.\<handle\>.sent.count) 
Modify zipkin to correctly increment discardedTraces and processedBatches when span ingest feature is disabled to keep consistent with what Jaeger does currently.