### PR TITLE
Propagate all Jaeger process tags as span tags

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerProtobufUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerProtobufUtils.java
@@ -94,10 +94,23 @@ public abstract class JaegerProtobufUtils {
     String serviceName = batch.getProcess().getServiceName();
     List<Annotation> processAnnotations = new ArrayList<>();
     boolean isSourceProcessTagPresent = false;
+    String cluster = NULL_TAG_VAL;
+    String shard = NULL_TAG_VAL;
+
     if (batch.getProcess().getTagsList() != null) {
       for (Model.KeyValue tag : batch.getProcess().getTagsList()) {
         if (tag.getKey().equals(APPLICATION_TAG_KEY) && tag.getVType() == Model.ValueType.STRING) {
           applicationName = tag.getVStr();
+          continue;
+        }
+
+       if (tag.getKey().equals(CLUSTER_TAG_KEY) && tag.getVType() == Model.ValueType.STRING) {
+          cluster = tag.getVStr();
+          continue;
+        }
+
+       if (tag.getKey().equals(SHARD_TAG_KEY) && tag.getVType() == Model.ValueType.STRING) {
+          shard = tag.getVStr();
           continue;
         }
 
@@ -133,7 +146,7 @@ public abstract class JaegerProtobufUtils {
     }
     receivedSpansTotal.inc(batch.getSpansCount());
     for (Model.Span span : batch.getSpansList()) {
-      processSpan(span, serviceName, sourceName, applicationName, processAnnotations,
+      processSpan(span, serviceName, sourceName, applicationName, cluster, shard, processAnnotations,
           spanHandler, spanLogsHandler, wfInternalReporter, spanLogsDisabled,
           preprocessorSupplier, sampler, traceDerivedCustomTagKeys,
           discardedSpansBySampler, discoveredHeartbeatMetrics);
@@ -144,6 +157,8 @@ public abstract class JaegerProtobufUtils {
                                   String serviceName,
                                   String sourceName,
                                   String applicationName,
+                                  String cluster,
+                                  String shard,
                                   List<Annotation> processAnnotations,
                                   ReportableEntityHandler<Span, String> spanHandler,
                                   ReportableEntityHandler<SpanLogs, String> spanLogsHandler,
@@ -158,8 +173,6 @@ public abstract class JaegerProtobufUtils {
     // serviceName is mandatory in Jaeger
     annotations.add(new Annotation(SERVICE_TAG_KEY, serviceName));
 
-    String cluster = NULL_TAG_VAL;
-    String shard = NULL_TAG_VAL;
     String componentTagValue = NULL_TAG_VAL;
     boolean isError = false;
     boolean isDebugSpanTag = false;

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerProtobufUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerProtobufUtils.java
@@ -116,13 +116,12 @@ public abstract class JaegerProtobufUtils {
           continue;
         }
 
-        //TODO: Propagate other Jaeger process tags as span tags
-        if (tag.getKey().equals("ip")) {
-          Annotation annotation = tagToAnnotation(tag);
-          processAnnotations.add(annotation);
-        }
+
+        Annotation annotation = tagToAnnotation(tag);
+        processAnnotations.add(annotation);
       }
     }
+
     if (isFeatureDisabled(traceDisabled, SPAN_DISABLED, discardedBatches, output)) {
       discardedTraces.inc(batch.getSpansCount());
       receivedSpansTotal.inc(batch.getSpansCount());

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerProtobufUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerProtobufUtils.java
@@ -116,6 +116,10 @@ public abstract class JaegerProtobufUtils {
           continue;
         }
 
+        if (tag.getKey().equals(SERVICE_TAG_KEY) && tag.getVType() == Model.ValueType.STRING) {
+          // ignore "service" tags, since service is a field on the span
+          continue;
+        }
 
         Annotation annotation = tagToAnnotation(tag);
         processAnnotations.add(annotation);
@@ -180,9 +184,12 @@ public abstract class JaegerProtobufUtils {
             case SHARD_TAG_KEY:
               shard = annotation.getValue();
               continue;
-              // Do not add source to annotation span tag list.
             case SOURCE_KEY:
+              // Do not add source to annotation span tag list.
               sourceName = annotation.getValue();
+              continue;
+            case SERVICE_TAG_KEY:
+              // Do not use service tag from annotations, use field instead
               continue;
             case COMPONENT_TAG_KEY:
               componentTagValue = annotation.getValue();

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
@@ -89,10 +89,23 @@ public abstract class JaegerThriftUtils {
     String serviceName = batch.getProcess().getServiceName();
     List<Annotation> processAnnotations = new ArrayList<>();
     boolean isSourceProcessTagPresent = false;
+    String cluster = NULL_TAG_VAL;
+    String shard = NULL_TAG_VAL;
+
     if (batch.getProcess().getTags() != null) {
       for (Tag tag : batch.getProcess().getTags()) {
         if (tag.getKey().equals(APPLICATION_TAG_KEY) && tag.getVType() == TagType.STRING) {
           applicationName = tag.getVStr();
+          continue;
+        }
+
+        if (tag.getKey().equals(CLUSTER_TAG_KEY) && tag.getVType() == TagType.STRING) {
+          cluster = tag.getVStr();
+          continue;
+        }
+
+        if (tag.getKey().equals(SHARD_TAG_KEY) && tag.getVType() == TagType.STRING) {
+          shard = tag.getVStr();
           continue;
         }
 
@@ -127,7 +140,7 @@ public abstract class JaegerThriftUtils {
     }
     receivedSpansTotal.inc(batch.getSpansSize());
     for (io.jaegertracing.thriftjava.Span span : batch.getSpans()) {
-      processSpan(span, serviceName, sourceName, applicationName, processAnnotations,
+      processSpan(span, serviceName, sourceName, applicationName, cluster, shard, processAnnotations,
           spanHandler, spanLogsHandler, wfInternalReporter, spanLogsDisabled,
           preprocessorSupplier, sampler, traceDerivedCustomTagKeys, discardedSpansBySampler,
           discoveredHeartbeatMetrics);
@@ -138,6 +151,8 @@ public abstract class JaegerThriftUtils {
                                   String serviceName,
                                   String sourceName,
                                   String applicationName,
+                                  String cluster,
+                                  String shard,
                                   List<Annotation> processAnnotations,
                                   ReportableEntityHandler<Span, String> spanHandler,
                                   ReportableEntityHandler<SpanLogs, String> spanLogsHandler,
@@ -163,8 +178,6 @@ public abstract class JaegerThriftUtils {
       annotations.add(new Annotation("parent", new UUID(0, parentSpanId).toString()));
     }
 
-    String cluster = NULL_TAG_VAL;
-    String shard = NULL_TAG_VAL;
     String componentTagValue = NULL_TAG_VAL;
     boolean isError = false;
     boolean isDebugSpanTag = false;

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
@@ -111,6 +111,11 @@ public abstract class JaegerThriftUtils {
           continue;
         }
 
+        if (tag.getKey().equals(SERVICE_TAG_KEY) && tag.getVType() == TagType.STRING) {
+          // ignore "service" tags, since service is a field on the span
+          continue;
+        }
+
         Annotation annotation = tagToAnnotation(tag);
         processAnnotations.add(annotation);
       }
@@ -184,9 +189,12 @@ public abstract class JaegerThriftUtils {
             case SHARD_TAG_KEY:
               shard = annotation.getValue();
               continue;
-              // Do not add source to annotation span tag list.
             case SOURCE_KEY:
+              // Do not add source to annotation span tag list.
               sourceName = annotation.getValue();
+              continue;
+            case SERVICE_TAG_KEY:
+              // Do not use service tag from annotations, use field instead
               continue;
             case COMPONENT_TAG_KEY:
               componentTagValue = annotation.getValue();

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftUtils.java
@@ -111,11 +111,8 @@ public abstract class JaegerThriftUtils {
           continue;
         }
 
-        //TODO: Propagate other Jaeger process tags as span tags
-        if (tag.getKey().equals("ip")) {
-          Annotation annotation = tagToAnnotation(tag);
-          processAnnotations.add(annotation);
-        }
+        Annotation annotation = tagToAnnotation(tag);
+        processAnnotations.add(annotation);
       }
     }
     if (isFeatureDisabled(traceDisabled, SPAN_DISABLED, discardedBatches, output)) {

--- a/proxy/src/test/java/com/wavefront/agent/listeners/tracing/JaegerGrpcCollectorHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/tracing/JaegerGrpcCollectorHandlerTest.java
@@ -53,12 +53,12 @@ import static org.junit.Assert.assertEquals;
  */
 public class JaegerGrpcCollectorHandlerTest {
   private final static String DEFAULT_SOURCE = "jaeger";
-  private ReportableEntityHandler<Span, String> mockTraceHandler =
+  private final ReportableEntityHandler<Span, String> mockTraceHandler =
       MockReportableEntityHandlerFactory.getMockTraceHandler();
-  private ReportableEntityHandler<SpanLogs, String> mockTraceLogsHandler =
+  private final ReportableEntityHandler<SpanLogs, String> mockTraceLogsHandler =
       MockReportableEntityHandlerFactory.getMockTraceSpanLogsHandler();
-  private WavefrontSender mockWavefrontSender = EasyMock.createMock(WavefrontSender.class);
-  private long startTime = System.currentTimeMillis();
+  private final WavefrontSender mockWavefrontSender = EasyMock.createMock(WavefrontSender.class);
+  private final long startTime = System.currentTimeMillis();
 
   // Derived RED metrics related.
   private final String PREPROCESSED_APPLICATION_TAG_VALUE = "preprocessedApplication";
@@ -272,19 +272,7 @@ public class JaegerGrpcCollectorHandlerTest {
     Collector.PostSpansRequest batches =
         Collector.PostSpansRequest.newBuilder().setBatch(testBatch).build();
 
-    handler.postSpans(batches, new StreamObserver<Collector.PostSpansResponse>() {
-      @Override
-      public void onNext(Collector.PostSpansResponse postSpansResponse) {
-      }
-
-      @Override
-      public void onError(Throwable throwable) {
-      }
-
-      @Override
-      public void onCompleted() {
-      }
-    });
+    handler.postSpans(batches, emptyStreamObserver);
 
     verify(mockTraceHandler, mockTraceLogsHandler);
   }
@@ -438,20 +426,6 @@ public class JaegerGrpcCollectorHandlerTest {
         addReferences(Model.SpanRef.newBuilder().setRefType(Model.SpanRefType.CHILD_OF).setSpanId(span3ParentId).setTraceId(traceId).build()).
         build();
 
-    StreamObserver<Collector.PostSpansResponse> streamObserver = new StreamObserver<Collector.PostSpansResponse>() {
-      @Override
-      public void onNext(Collector.PostSpansResponse postSpansResponse) {
-      }
-
-      @Override
-      public void onError(Throwable throwable) {
-      }
-
-      @Override
-      public void onCompleted() {
-      }
-    };
-
     Model.Batch testBatch = Model.Batch.newBuilder().
         setProcess(Model.Process.newBuilder().setServiceName("frontend").addTags(ipTag).addTags(processLevelAppTag).build()).
         addAllSpans(ImmutableList.of(span1, span2)).
@@ -460,7 +434,7 @@ public class JaegerGrpcCollectorHandlerTest {
     Collector.PostSpansRequest batches =
         Collector.PostSpansRequest.newBuilder().setBatch(testBatch).build();
 
-    handler.postSpans(batches, streamObserver);
+    handler.postSpans(batches, emptyStreamObserver);
 
     Model.Batch testBatchForProxyLevel = Model.Batch.newBuilder().
         setProcess(Model.Process.newBuilder().setServiceName("frontend").addTags(ipTag).build()).
@@ -470,7 +444,7 @@ public class JaegerGrpcCollectorHandlerTest {
     Collector.PostSpansRequest batchesForProxyLevel =
         Collector.PostSpansRequest.newBuilder().setBatch(testBatchForProxyLevel).build();
 
-    handler.postSpans(batchesForProxyLevel, streamObserver);
+    handler.postSpans(batchesForProxyLevel, emptyStreamObserver);
 
     verify(mockTraceHandler, mockTraceLogsHandler);
   }
@@ -546,19 +520,7 @@ public class JaegerGrpcCollectorHandlerTest {
     Collector.PostSpansRequest batches =
         Collector.PostSpansRequest.newBuilder().setBatch(testBatch).build();
 
-    handler.postSpans(batches, new StreamObserver<Collector.PostSpansResponse>() {
-      @Override
-      public void onNext(Collector.PostSpansResponse postSpansResponse) {
-      }
-
-      @Override
-      public void onError(Throwable throwable) {
-      }
-
-      @Override
-      public void onCompleted() {
-      }
-    });
+    handler.postSpans(batches, emptyStreamObserver);
 
     verify(mockTraceHandler, mockTraceLogsHandler);
   }
@@ -666,19 +628,7 @@ public class JaegerGrpcCollectorHandlerTest {
     Collector.PostSpansRequest batches =
         Collector.PostSpansRequest.newBuilder().setBatch(testBatch).build();
 
-    handler.postSpans(batches, new StreamObserver<Collector.PostSpansResponse>() {
-      @Override
-      public void onNext(Collector.PostSpansResponse postSpansResponse) {
-      }
-
-      @Override
-      public void onError(Throwable throwable) {
-      }
-
-      @Override
-      public void onCompleted() {
-      }
-    });
+    handler.postSpans(batches, emptyStreamObserver);
 
     verify(mockTraceHandler, mockTraceLogsHandler);
   }
@@ -814,20 +764,6 @@ public class JaegerGrpcCollectorHandlerTest {
         setStartTime(fromMillis(startTime)).
         build();
 
-    StreamObserver<Collector.PostSpansResponse> streamObserver = new StreamObserver<Collector.PostSpansResponse>() {
-      @Override
-      public void onNext(Collector.PostSpansResponse postSpansResponse) {
-      }
-
-      @Override
-      public void onError(Throwable throwable) {
-      }
-
-      @Override
-      public void onCompleted() {
-      }
-    };
-
     Model.Batch testBatch = Model.Batch.newBuilder().
         setProcess(Model.Process.newBuilder().setServiceName("frontend").addTags(ipTag).addTags(hostNameProcessTag).addTags(customSourceProcessTag).build()).
         addAllSpans(ImmutableList.of(span1, span2)).
@@ -836,7 +772,7 @@ public class JaegerGrpcCollectorHandlerTest {
     Collector.PostSpansRequest batches =
         Collector.PostSpansRequest.newBuilder().setBatch(testBatch).build();
 
-    handler.postSpans(batches, streamObserver);
+    handler.postSpans(batches, emptyStreamObserver);
 
     Model.Batch testBatchForProxyLevel = Model.Batch.newBuilder().
         setProcess(Model.Process.newBuilder().setServiceName("frontend").addTags(ipTag).addTags(hostNameProcessTag).build()).
@@ -846,7 +782,7 @@ public class JaegerGrpcCollectorHandlerTest {
     Collector.PostSpansRequest batchesSourceAsProcessTagHostName =
         Collector.PostSpansRequest.newBuilder().setBatch(testBatchForProxyLevel).build();
 
-    handler.postSpans(batchesSourceAsProcessTagHostName, streamObserver);
+    handler.postSpans(batchesSourceAsProcessTagHostName, emptyStreamObserver);
 
     verify(mockTraceHandler, mockTraceLogsHandler);
   }
@@ -920,10 +856,6 @@ public class JaegerGrpcCollectorHandlerTest {
     ByteString traceId = ByteString.copyFrom(buffer.array());
 
     buffer = ByteBuffer.allocate(Long.BYTES);
-    buffer.putLong(2345678L);
-    ByteString span1Id = ByteString.copyFrom(buffer.array());
-
-    buffer = ByteBuffer.allocate(Long.BYTES);
     buffer.putLong(1234567L);
     ByteString span2Id = ByteString.copyFrom(buffer.array());
 
@@ -943,7 +875,18 @@ public class JaegerGrpcCollectorHandlerTest {
     Collector.PostSpansRequest batches =
         Collector.PostSpansRequest.newBuilder().setBatch(testBatch).build();
 
-    handler.postSpans(batches, new StreamObserver<Collector.PostSpansResponse>() {
+    handler.postSpans(batches, emptyStreamObserver);
+    handler.run();
+
+    verifyWithTimeout(500, mockTraceHandler, mockWavefrontSender);
+    HashMap<String, String> tagsReturned = tagsCapture.getValue();
+    assertEquals(PREPROCESSED_APPLICATION_TAG_VALUE, tagsReturned.get(APPLICATION_TAG_KEY));
+    assertEquals(PREPROCESSED_SERVICE_TAG_VALUE, tagsReturned.get(SERVICE_TAG_KEY));
+    assertEquals(PREPROCESSED_CLUSTER_TAG_VALUE, tagsReturned.get(CLUSTER_TAG_KEY));
+    assertEquals(PREPROCESSED_SHARD_TAG_VALUE, tagsReturned.get(SHARD_TAG_KEY));
+  }
+
+  private final StreamObserver<Collector.PostSpansResponse> emptyStreamObserver = new StreamObserver<Collector.PostSpansResponse>() {
       @Override
       public void onNext(Collector.PostSpansResponse postSpansResponse) {
       }
@@ -955,14 +898,6 @@ public class JaegerGrpcCollectorHandlerTest {
       @Override
       public void onCompleted() {
       }
-    });
-    handler.run();
+    };
 
-    verifyWithTimeout(500, mockTraceHandler, mockWavefrontSender);
-    HashMap<String, String> tagsReturned = tagsCapture.getValue();
-    assertEquals(PREPROCESSED_APPLICATION_TAG_VALUE, tagsReturned.get(APPLICATION_TAG_KEY));
-    assertEquals(PREPROCESSED_SERVICE_TAG_VALUE, tagsReturned.get(SERVICE_TAG_KEY));
-    assertEquals(PREPROCESSED_CLUSTER_TAG_VALUE, tagsReturned.get(CLUSTER_TAG_KEY));
-    assertEquals(PREPROCESSED_SHARD_TAG_VALUE, tagsReturned.get(SHARD_TAG_KEY));
-  }
 }


### PR DESCRIPTION
This removes the filter for `ip` tags when forwarding Jaeger traces and fixes #423.