### PR TITLE
Reduce disk space allocation when queueing

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -374,7 +374,7 @@
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.8</minimum>
+                      <minimum>0.80</minimum>
                     </limit>
                   </limits>
                 </rule>
@@ -400,7 +400,7 @@
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.9</minimum>
+                      <minimum>0.90</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -277,9 +277,12 @@ public abstract class AbstractAgent {
       // If we are exporting data from the queue, run export and exit
       if (proxyConfig.getExportQueueOutputFile() != null &&
           proxyConfig.getExportQueuePorts() != null) {
-        TaskQueueFactory tqFactory = new TaskQueueFactoryImpl(proxyConfig.getBufferFile(), false);
+        TaskQueueFactory tqFactory = new TaskQueueFactoryImpl(proxyConfig.getBufferFile(), false,
+            false, proxyConfig.getBufferShardSize());
         EntityPropertiesFactory epFactory = new EntityPropertiesFactoryImpl(proxyConfig);
-        QueueExporter queueExporter = new QueueExporter(proxyConfig, tqFactory, epFactory);
+        QueueExporter queueExporter = new QueueExporter(proxyConfig.getBufferFile(),
+            proxyConfig.getExportQueuePorts(), proxyConfig.getExportQueueOutputFile(),
+            proxyConfig.isExportQueueRetainData(), tqFactory, epFactory);
         logger.info("Starting queue export for ports: " + proxyConfig.getExportQueuePorts());
         queueExporter.export();
         logger.info("Done");
@@ -326,7 +329,8 @@ public abstract class AbstractAgent {
           5000
       );
     } catch (Exception e) {
-      logger.severe(e.getMessage());
+      logger.log(Level.SEVERE, e.getMessage(), e);
+//      logger.severe(e.getMessage());
       System.exit(1);
     }
   }

--- a/proxy/src/main/java/com/wavefront/agent/ProxyConfig.java
+++ b/proxy/src/main/java/com/wavefront/agent/ProxyConfig.java
@@ -86,12 +86,22 @@ public class ProxyConfig extends Configuration {
   @Parameter(names = {"-h", "--host"}, description = "Server URL", order = 2)
   String server = "http://localhost:8080/api/";
 
-  @Parameter(names = {"--buffer"}, description = "File to use for buffering transmissions " +
-      "to be retried. Defaults to /var/spool/wavefront-proxy/buffer.", order = 7)
+  @Parameter(names = {"--buffer"}, description = "File name prefix to use for buffering " +
+      "transmissions to be retried. Defaults to /var/spool/wavefront-proxy/buffer.", order = 7)
   String bufferFile = "/var/spool/wavefront-proxy/buffer";
 
+  @Parameter(names = {"--bufferShardSize"}, description = "Buffer file partition size, in MB. " +
+      "Setting this value too low may reduce the efficiency of disk space utilization, " +
+      "while setting this value too high will allocate disk space in larger increments. " +
+      "Default: 128")
+  int bufferShardSize = 128;
+
+  @Parameter(names = {"--disableBufferSharding"}, description = "Use single-file buffer " +
+      "(legacy functionality). Default: false", arity = 1)
+  boolean disableBufferSharding = false;
+
   @Parameter(names = {"--sqsBuffer"}, description = "Use AWS SQS Based for buffering transmissions " +
-      "to be retried. Defaults to False")
+      "to be retried. Defaults to False", arity = 1)
   boolean sqsQueueBuffer = false;
 
   @Parameter(names = {"--sqsQueueNameTemplate"}, description = "The replacement pattern to use for naming the " +
@@ -835,6 +845,14 @@ public class ProxyConfig extends Configuration {
 
   public String getBufferFile() {
     return bufferFile;
+  }
+
+  public int getBufferShardSize() {
+    return bufferShardSize;
+  }
+
+  public boolean isDisableBufferSharding() {
+    return disableBufferSharding;
   }
 
   public boolean isSqsQueueBuffer() {
@@ -1805,6 +1823,8 @@ public class ProxyConfig extends Configuration {
           config.getNumber("pushRelayHistogramAggregatorCompression",
               pushRelayHistogramAggregatorCompression).shortValue();
       bufferFile = config.getString("buffer", bufferFile);
+      bufferShardSize = config.getInteger("bufferShardSize", bufferShardSize);
+      disableBufferSharding = config.getBoolean("disableBufferSharding", disableBufferSharding);
       taskQueueLevel = TaskQueueLevel.fromString(config.getString("taskQueueStrategy",
           taskQueueLevel.toString()));
       purgeBuffer = config.getBoolean("purgeBuffer", purgeBuffer);

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -223,7 +223,8 @@ public class PushAgent extends AbstractAgent {
           proxyConfig.isPurgeBuffer());
     } else {
       taskQueueFactory = new TaskQueueFactoryImpl(proxyConfig.getBufferFile(),
-          proxyConfig.isPurgeBuffer());
+          proxyConfig.isPurgeBuffer(), proxyConfig.isDisableBufferSharding(),
+          proxyConfig.getBufferShardSize());
     }
 
     remoteHostAnnotator = new SharedGraphiteHostAnnotator(proxyConfig.getCustomSourceTags(),

--- a/proxy/src/main/java/com/wavefront/agent/queueing/ConcurrentQueueFile.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/ConcurrentQueueFile.java
@@ -1,0 +1,103 @@
+package com.wavefront.agent.queueing;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A thread-safe wrapper for {@link QueueFile}. This version assumes that operations on the head
+ * and on the tail of the queue are mutually exclusive and should be synchronized. For a more
+ * fine-grained  implementation, see {@link ConcurrentShardedQueueFile} that maintains separate
+ * locks on the head and the tail of the queue.
+ *
+ * @author vasily@wavefront.com
+ */
+public class ConcurrentQueueFile implements QueueFile {
+
+  private final QueueFile delegate;
+  private final ReentrantLock lock = new ReentrantLock(true);
+
+  public ConcurrentQueueFile(QueueFile delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void add(byte[] data, int offset, int count) throws IOException {
+    lock.lock();
+    try {
+      delegate.add(data, offset, count);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void clear() throws IOException {
+    lock.lock();
+    try {
+      delegate.clear();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Nullable
+  @Override
+  public byte[] peek() throws IOException {
+    lock.lock();
+    try {
+      return delegate.peek();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void remove() throws IOException {
+    lock.lock();
+    try {
+      delegate.remove();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public long storageBytes() {
+    return delegate.storageBytes();
+  }
+
+  @Override
+  public long usedBytes() {
+    return delegate.usedBytes();
+  }
+
+  @Override
+  public long availableBytes() {
+    return delegate.availableBytes();
+  }
+
+  @Override
+  public void close() throws IOException {
+    lock.lock();
+    try {
+      delegate.close();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @NotNull
+  @Override
+  public Iterator<byte[]> iterator() {
+    return delegate.iterator();
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/queueing/ConcurrentShardedQueueFile.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/ConcurrentShardedQueueFile.java
@@ -1,0 +1,363 @@
+package com.wavefront.agent.queueing;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ObjectUtils;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.wavefront.common.Utils;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A thread-safe {@link QueueFile} implementation, that uses multiple smaller "shard" files
+ * instead of one large file. This also improves concurrency - when we have more than one file,
+ * we can add and remove tasks at the same time without mutually exclusive locking.
+ *
+ * @author vasily@wavefront.com
+ */
+public class ConcurrentShardedQueueFile implements QueueFile {
+  private static final int HEADER_SIZE_BYTES = 36;
+  private static final int TASK_HEADER_SIZE_BYTES = 4;
+  private static final int SUFFIX_DIGITS = 4;
+
+  private final String fileNamePrefix;
+  private final String fileNameSuffix;
+  private final int shardSizeBytes;
+  private final QueueFileFactory queueFileFactory;
+
+  @VisibleForTesting
+  final Deque<Shard> shards = new ConcurrentLinkedDeque<>();
+  private final ReentrantLock globalLock = new ReentrantLock(true);
+  private final ReentrantLock tailLock = new ReentrantLock(true);
+  private final ReentrantLock headLock = new ReentrantLock(true);
+  private volatile boolean closed = false;
+  private volatile byte[] head;
+  private final AtomicLong modCount = new AtomicLong();
+
+  /**
+   * @param fileNamePrefix   path + file name prefix for shard files
+   * @param fileNameSuffix   file name suffix to identify shard files
+   * @param shardSizeBytes   target shard size bytes
+   * @param queueFileFactory factory for {@link QueueFile} objects
+   * @throws IOException if file(s) could not be created or accessed
+   */
+  public ConcurrentShardedQueueFile(String fileNamePrefix,
+                                    String fileNameSuffix,
+                                    int shardSizeBytes,
+                                    QueueFileFactory queueFileFactory) throws IOException {
+    this.fileNamePrefix = fileNamePrefix;
+    this.fileNameSuffix = fileNameSuffix;
+    this.shardSizeBytes = shardSizeBytes;
+    this.queueFileFactory = queueFileFactory;
+    //noinspection unchecked
+    for (String filename : ObjectUtils.firstNonNull(listFiles(fileNamePrefix, fileNameSuffix),
+        ImmutableList.of(getInitialFilename()))) {
+      Shard shard = new Shard(filename);
+      // don't keep the QueueFile open within the shard object until it's actually needed,
+      // as we don't want to keep too many files open.
+      shard.close();
+      this.shards.add(shard);
+    }
+  }
+
+  @Nullable
+  @Override
+  public byte[] peek() throws IOException {
+    checkForClosedState();
+    headLock.lock();
+    try {
+      if (this.head == null) {
+        globalLock.lock();
+        Shard shard = shards.getFirst().updateStats();
+        if (shards.size() > 1) {
+          globalLock.unlock();
+        }
+        this.head = Objects.requireNonNull(shard.queueFile).peek();
+      }
+      return this.head;
+    } finally {
+      headLock.unlock();
+      if (globalLock.isHeldByCurrentThread()) {
+        globalLock.unlock();
+      }
+    }
+  }
+
+  @Override
+  public void add(byte[] data, int offset, int count) throws IOException {
+    checkForClosedState();
+    tailLock.lock();
+    try {
+      globalLock.lock();
+      // check whether we need to allocate a new shard
+      Shard shard = shards.getLast();
+      if (shard.newShardRequired(count)) {
+        // allocate new shard unless the task is oversized and current shard is empty
+        if (shards.size() > 1) {
+          // we don't want to close if that shard was the head
+          shard.close();
+        }
+        String newFileName = incrementFileName(shard.shardFileName, fileNameSuffix);
+        shard = new Shard(newFileName);
+        shards.addLast(shard);
+      }
+      shard.updateStats();
+      modCount.incrementAndGet();
+      if (shards.size() > 2) {
+        globalLock.unlock();
+      }
+      Objects.requireNonNull(shard.queueFile).add(data, offset, count);
+      shard.updateStats();
+    } finally {
+      tailLock.unlock();
+      if (globalLock.isHeldByCurrentThread()) {
+        globalLock.unlock();
+      }
+    }
+  }
+
+  @Override
+  public void remove() throws IOException {
+    checkForClosedState();
+    headLock.lock();
+    try {
+      this.head = null;
+      Shard shard = shards.getFirst().updateStats();
+      if (shards.size() == 1) {
+        globalLock.lock();
+      }
+      modCount.incrementAndGet();
+      Objects.requireNonNull(shard.queueFile).remove();
+      shard.updateStats();
+      // check whether we have removed the last task in a shard
+      if (shards.size() > 1 && shard.numTasks == 0) {
+        shard.close();
+        shards.removeFirst();
+        new File(shard.shardFileName).delete();
+      }
+    } finally {
+      headLock.unlock();
+      if (globalLock.isHeldByCurrentThread()) {
+        globalLock.unlock();
+      }
+    }
+  }
+
+  @Override
+  public int size() {
+    return shards.stream().mapToInt(shard -> shard.numTasks).sum();
+  }
+
+  @Override
+  public long storageBytes() {
+    return shards.stream().mapToLong(shard -> shard.fileLength).sum();
+  }
+
+  @Override
+  public long usedBytes() {
+    return shards.stream().mapToLong(shard -> shard.usedBytes).sum();
+  }
+
+  @Override
+  public long availableBytes() {
+    Shard shard = shards.getLast();
+    return shard.fileLength - shard.usedBytes;
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.closed = true;
+    for (Shard shard : shards) {
+      shard.close();
+    }
+  }
+
+  @Override
+  public void clear() throws IOException {
+    this.headLock.lock();
+    this.tailLock.lock();
+    try {
+      this.head = null;
+      for (Shard shard : shards) {
+        shard.close();
+        new File(shard.shardFileName).delete();
+      }
+      shards.clear();
+      shards.add(new Shard(getInitialFilename()));
+      modCount.incrementAndGet();
+    } finally {
+      this.headLock.unlock();
+      this.tailLock.unlock();
+    }
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<byte[]> iterator() {
+    checkForClosedState();
+    return new ShardedIterator();
+  }
+
+  private final class ShardedIterator implements Iterator<byte[]> {
+    long expectedModCount = modCount.get();
+    Iterator<byte[]> currentIterator = Collections.emptyIterator();
+    Shard currentShard = null;
+    Iterator<Shard> shardIterator = shards.iterator();
+    int nextElementIndex = 0;
+
+    ShardedIterator() {
+    }
+
+    private void checkForComodification() {
+      checkForClosedState();
+      if (modCount.get() != expectedModCount) {
+        throw new ConcurrentModificationException();
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      checkForComodification();
+      try {
+        while (!checkNotNull(currentIterator).hasNext()) {
+          if (!shardIterator.hasNext()) {
+            return false;
+          }
+          currentShard = shardIterator.next().updateStats();
+          currentIterator = Objects.requireNonNull(currentShard.queueFile).iterator();
+        }
+      } catch (IOException e) {
+        throw Utils.<Error>throwAny(e);
+      }
+      return true;
+    }
+
+    @Override
+    public byte[] next() {
+      checkForComodification();
+      if (hasNext()) {
+        nextElementIndex++;
+        return currentIterator.next();
+      } else {
+        throw new NoSuchElementException();
+      }
+    }
+
+    @Override
+    public void remove() {
+      checkForComodification();
+      if (nextElementIndex > 1) {
+        throw new UnsupportedOperationException("Removal is only permitted from the head.");
+      }
+      try {
+        currentIterator.remove();
+        currentShard.updateStats();
+        nextElementIndex--;
+      } catch (IOException e) {
+        throw Utils.<Error>throwAny(e);
+      }
+    }
+  }
+
+  private final class Shard {
+    private final String shardFileName;
+    @Nullable private QueueFile queueFile;
+    private long fileLength;
+    private Long usedBytes;
+    private int numTasks;
+
+    private Shard(String shardFileName) throws IOException {
+      this.shardFileName = shardFileName;
+      updateStats();
+    }
+
+    @CanIgnoreReturnValue
+    private Shard updateStats() throws IOException {
+      if (this.queueFile == null) {
+        this.queueFile = queueFileFactory.get(this.shardFileName);
+      }
+      if (this.queueFile != null) {
+        this.fileLength = this.queueFile.storageBytes();
+        this.numTasks = this.queueFile.size();
+        this.usedBytes = this.queueFile.usedBytes();
+      }
+      return this;
+    }
+
+    private void close() throws IOException {
+      if (this.queueFile != null) {
+        this.queueFile.close();
+        this.queueFile = null;
+      }
+    }
+
+    private boolean newShardRequired(int taskSize) {
+      return (taskSize > (shardSizeBytes - this.usedBytes - TASK_HEADER_SIZE_BYTES) &&
+          (taskSize <= (shardSizeBytes - HEADER_SIZE_BYTES) || this.numTasks > 0));
+    }
+  }
+
+  private void checkForClosedState() {
+    if (closed) {
+      throw new IllegalStateException("closed");
+    }
+  }
+
+  private String getInitialFilename() {
+    return new File(fileNamePrefix).exists() ?
+        fileNamePrefix :
+        incrementFileName(fileNamePrefix, fileNameSuffix);
+  }
+
+  @VisibleForTesting
+  @Nullable
+  static List<String> listFiles(String path, String suffix) {
+    String fnPrefix = Iterators.getLast(Splitter.on('/').split(path).iterator());
+    Pattern pattern = getSuffixMatchingPattern(suffix);
+    File bufferFilePath = new File(path);
+    File[] files = bufferFilePath.getParentFile().listFiles((dir, fileName) ->
+        (fileName.endsWith(suffix) || pattern.matcher(fileName).matches()) &&
+            fileName.startsWith(fnPrefix));
+    return (files == null || files.length == 0) ? null :
+        Arrays.stream(files).map(File::getAbsolutePath).sorted().collect(Collectors.toList());
+  }
+
+  @VisibleForTesting
+  static String incrementFileName(String fileName, String suffix) {
+    Pattern pattern = getSuffixMatchingPattern(suffix);
+    String zeroes = StringUtils.repeat("0", SUFFIX_DIGITS);
+    if (pattern.matcher(fileName).matches()) {
+      int nextId = Integer.parseInt(StringUtils.right(fileName, SUFFIX_DIGITS), 16) + 1;
+      String newHex = StringUtils.right(zeroes + Long.toHexString(nextId), SUFFIX_DIGITS);
+      return StringUtils.left(fileName, fileName.length() - SUFFIX_DIGITS) + newHex;
+    } else {
+      return fileName + "_" + zeroes;
+    }
+  }
+
+  private static Pattern getSuffixMatchingPattern(String suffix) {
+    return Pattern.compile("^.*" + Pattern.quote(suffix) + "_[0-9a-f]{" + SUFFIX_DIGITS + "}$");
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/queueing/DirectByteArrayOutputStream.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/DirectByteArrayOutputStream.java
@@ -1,0 +1,17 @@
+package com.wavefront.agent.queueing;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * Enables direct access to the internal array. Avoids unnecessary copying.
+ */
+public final class DirectByteArrayOutputStream extends ByteArrayOutputStream {
+
+  /**
+   * Gets a reference to the internal byte array.  The {@link #size()} method indicates how many
+   * bytes contain actual data added since the last {@link #reset()} call.
+   */
+  byte[] getArray() {
+    return buf;
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/queueing/FileBasedTaskQueue.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/FileBasedTaskQueue.java
@@ -1,15 +1,11 @@
 package com.wavefront.agent.queueing;
 
-import com.squareup.tape2.QueueFile;
 import com.wavefront.agent.data.DataSubmissionTask;
 import com.wavefront.common.Utils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
@@ -23,21 +19,10 @@ import java.util.logging.Logger;
  */
 public class FileBasedTaskQueue<T extends DataSubmissionTask<T>> implements TaskQueue<T> {
   private static final Logger log = Logger.getLogger(FileBasedTaskQueue.class.getCanonicalName());
-  private static final Method getAvailableBytes;
-
-  static {
-    try {
-      Class<?> classQueueFile = Class.forName("com.squareup.tape2.QueueFile");
-      getAvailableBytes = classQueueFile.getDeclaredMethod("remainingBytes");
-      getAvailableBytes.setAccessible(true);
-    } catch (ClassNotFoundException | NoSuchMethodException e) {
-      throw new AssertionError(e);
-    }
-  }
 
   private final DirectByteArrayOutputStream bytes = new DirectByteArrayOutputStream();
 
-  private volatile byte[] head;
+  private volatile T head;
 
   private final AtomicLong currentWeight = new AtomicLong();
   private final QueueFile queueFile;
@@ -50,7 +35,7 @@ public class FileBasedTaskQueue<T extends DataSubmissionTask<T>> implements Task
   public FileBasedTaskQueue(QueueFile queueFile, TaskConverter<T> taskConverter) {
     this.queueFile = queueFile;
     this.taskConverter = taskConverter;
-    log.fine("Enumerating " + queueFile.file().getAbsolutePath() + " queue");
+    log.fine("Enumerating queue");
     this.queueFile.iterator().forEachRemaining(task -> {
       Integer weight = taskConverter.getWeight(task);
       if (weight != null) {
@@ -64,11 +49,12 @@ public class FileBasedTaskQueue<T extends DataSubmissionTask<T>> implements Task
   public T peek() {
     try {
       if (this.head != null) {
-        return taskConverter.fromBytes(head);
+        return this.head;
       }
-      this.head = queueFile.peek();
-      if (this.head == null) return null;
-      return taskConverter.fromBytes(head);
+      byte[] task = queueFile.peek();
+      if (task == null) return null;
+      this.head = taskConverter.fromBytes(task);
+      return this.head;
     } catch (IOException ex) {
       throw Utils.<Error>throwAny(ex);
     }
@@ -92,13 +78,13 @@ public class FileBasedTaskQueue<T extends DataSubmissionTask<T>> implements Task
   @Override
   public void remove() throws IOException {
     if (this.head == null) {
-      this.head = queueFile.peek();
+      byte[] task = queueFile.peek();
+      if (task == null) return;
+      this.head = taskConverter.fromBytes(task);
     }
     queueFile.remove();
-    Integer weight = taskConverter.getWeight(this.head);
-    if (weight != null) {
-      currentWeight.getAndUpdate(x -> x > weight ? x - weight : 0);
-    }
+    int weight = this.head.weight();
+    currentWeight.getAndUpdate(x -> x > weight ? x - weight : 0);
     this.head = null;
   }
 
@@ -121,16 +107,7 @@ public class FileBasedTaskQueue<T extends DataSubmissionTask<T>> implements Task
   @Nullable
   @Override
   public Long getAvailableBytes()  {
-    try {
-      return (long) getAvailableBytes.invoke(queueFile);
-    } catch (InvocationTargetException | IllegalAccessException e) {
-      return null;
-    }
-  }
-
-  @Override
-  public String getName() {
-    return queueFile.file().getAbsolutePath();
+    return queueFile.storageBytes() - queueFile.usedBytes();
   }
 
   @Nonnull
@@ -159,19 +136,5 @@ public class FileBasedTaskQueue<T extends DataSubmissionTask<T>> implements Task
         iterator.remove();
       }
     };
-  }
-
-  /** Enables direct access to the internal array. Avoids unnecessary copying. */
-  private static final class DirectByteArrayOutputStream extends ByteArrayOutputStream {
-    DirectByteArrayOutputStream() {
-    }
-
-    /**
-     * Gets a reference to the internal byte array.  The {@link #size()} method indicates how many
-     * bytes contain actual data added since the last {@link #reset()} call.
-     */
-    byte[] getArray() {
-      return buf;
-    }
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/queueing/InMemorySubmissionQueue.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/InMemorySubmissionQueue.java
@@ -51,11 +51,6 @@ public class InMemorySubmissionQueue<T extends DataSubmissionTask<T>> implements
     return null;
   }
 
-  @Override
-  public String getName() {
-    return "unknown";
-  }
-
   @Nullable
   @Override
   public T peek() {

--- a/proxy/src/main/java/com/wavefront/agent/queueing/QueueFile.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/QueueFile.java
@@ -1,0 +1,88 @@
+package com.wavefront.agent.queueing;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+/**
+ * Proxy-specific FIFO queue interface for storing {@code byte[]}. This allows us to
+ * potentially support multiple backing storages in the future.
+ *
+ * @author vasily@wavefront.com
+ */
+public interface QueueFile extends Closeable, Iterable<byte[]> {
+  /**
+   * Adds an element to the end of the queue.
+   *
+   * @param data to copy bytes from
+   */
+  default void add(byte[] data) throws IOException {
+    add(data, 0, data.length);
+  }
+
+  /**
+   * Adds an element to the end of the queue.
+   *
+   * @param data to copy bytes from
+   * @param offset to start from in buffer
+   * @param count number of bytes to copy
+   * @throws IndexOutOfBoundsException if {@code offset < 0} or {@code count < 0}, or if {@code
+   * offset + count} is bigger than the length of {@code buffer}.
+   */
+  void add(byte[] data, int offset, int count) throws IOException;
+
+  /**
+   * Clears this queue. Truncates the file to the initial size.
+   */
+  void clear() throws IOException;
+
+  /**
+   * Checks whether this queue is empty.
+   *
+   * @return true if this queue contains no entries
+   */
+  default boolean isEmpty() {
+    return size() == 0;
+  }
+
+  /**
+   * Reads the eldest element. Returns null if the queue is empty.
+   *
+   * @return the eldest element.
+   */
+  @Nullable byte[] peek() throws IOException;
+
+  /**
+   * Removes the eldest element.
+   *
+   * @throws NoSuchElementException if the queue is empty
+   */
+  void remove() throws IOException;
+
+  /**
+   * Returns the number of elements in this queue.
+   */
+  int size();
+
+  /**
+   * Returns the storage size (on-disk file size) in bytes.
+   *
+   * @return file size in bytes.
+   */
+  long storageBytes();
+
+  /**
+   * Returns the number of bytes used for data.
+   *
+   * @return bytes used.
+   */
+  long usedBytes();
+
+  /**
+   * Returns the number of bytes available for adding new tasks without growing the file.
+   *
+   * @return bytes available.
+   */
+  long availableBytes();
+}

--- a/proxy/src/main/java/com/wavefront/agent/queueing/QueueFileFactory.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/QueueFileFactory.java
@@ -1,0 +1,20 @@
+package com.wavefront.agent.queueing;
+
+import java.io.IOException;
+
+/**
+ * Factory for {@link QueueFile} instances.
+ *
+ * @author vasily@wavefront.com
+ */
+public interface QueueFileFactory {
+
+  /**
+   * Creates, or accesses an existing file, with the specified name.
+   *
+   * @param fileName file name to use
+   * @return queue file instance
+   * @throws IOException if file could not be created or accessed
+   */
+  QueueFile get(String fileName) throws IOException;
+}

--- a/proxy/src/main/java/com/wavefront/agent/queueing/SQSQueueFactoryImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/SQSQueueFactoryImpl.java
@@ -74,11 +74,11 @@ public class SQSQueueFactoryImpl implements TaskQueueFactory {
     final String queueName = getQueueName(handlerKey);
     String queueUrl = queues.computeIfAbsent(queueName, x -> getOrCreateQueue(queueName));
     if (handlerKey.getEntityType() == ReportableEntityType.SOURCE_TAG) {
-      return new SynchronizedTaskQueueWithMetrics<T>(new InMemorySubmissionQueue<>(), "buffer.in-memory",
+      return new InstrumentedTaskQueueDelegate<T>(new InMemorySubmissionQueue<>(), "buffer.in-memory",
           ImmutableMap.of("port", handlerKey.getHandle()), handlerKey.getEntityType());
     }
     if (StringUtils.isNotBlank(queueUrl)) {
-      return new SynchronizedTaskQueueWithMetrics<>(new SQSSubmissionQueue<>(queueUrl,
+      return new InstrumentedTaskQueueDelegate<>(new SQSSubmissionQueue<>(queueUrl,
           AmazonSQSClientBuilder.standard().withRegion(this.region).build(),
           new RetryTaskConverter<T>(handlerKey.getHandle(),
               RetryTaskConverter.CompressionType.LZ4)),

--- a/proxy/src/main/java/com/wavefront/agent/queueing/SQSSubmissionQueue.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/SQSSubmissionQueue.java
@@ -171,11 +171,6 @@ public class SQSSubmissionQueue<T extends DataSubmissionTask<T>> implements Task
         "consider using size instead");
   }
 
-  @Override
-  public String getName() {
-    return queueUrl;
-  }
-
   @NotNull
   @Override
   public Iterator<T> iterator() {

--- a/proxy/src/main/java/com/wavefront/agent/queueing/TapeQueueFile.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/TapeQueueFile.java
@@ -1,0 +1,137 @@
+package com.wavefront.agent.queueing;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.function.BiConsumer;
+
+import com.wavefront.common.TimeProvider;
+
+/**
+ * A {@link com.squareup.tape2.QueueFile} to {@link QueueFile} adapter.
+ *
+ * @author vasily@wavefront.com
+ */
+public class TapeQueueFile implements QueueFile {
+  private static final Method usedBytes;
+  private static final Field fileLength;
+
+  static {
+    try {
+      Class<?> classQueueFile = Class.forName("com.squareup.tape2.QueueFile");
+      usedBytes = classQueueFile.getDeclaredMethod("usedBytes");
+      usedBytes.setAccessible(true);
+      fileLength = classQueueFile.getDeclaredField("fileLength");
+      fileLength.setAccessible(true);
+    } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private final com.squareup.tape2.QueueFile delegate;
+  @Nullable
+  private final BiConsumer<Integer, Long> writeStatsConsumer;
+  private final TimeProvider clock;
+
+  /**
+   * @param delegate           tape queue file
+   */
+  public TapeQueueFile(com.squareup.tape2.QueueFile delegate) {
+    this(delegate, null, null);
+  }
+
+  /**
+   * @param delegate           tape queue file
+   * @param writeStatsConsumer consumer for statistics on writes (bytes written and millis taken)
+   */
+  public TapeQueueFile(com.squareup.tape2.QueueFile delegate,
+                       @Nullable BiConsumer<Integer, Long> writeStatsConsumer) {
+    this(delegate, writeStatsConsumer, null);
+  }
+
+  /**
+   * @param delegate           tape queue file
+   * @param writeStatsConsumer consumer for statistics on writes (bytes written and millis taken)
+   * @param clock              time provider (in millis)
+   */
+  public TapeQueueFile(com.squareup.tape2.QueueFile delegate,
+                       @Nullable BiConsumer<Integer, Long> writeStatsConsumer,
+                       @Nullable TimeProvider clock) {
+    this.delegate = delegate;
+    this.writeStatsConsumer = writeStatsConsumer;
+    this.clock = clock == null ? System::currentTimeMillis : clock;
+  }
+
+  @Override
+  public void add(byte[] data, int offset, int count) throws IOException {
+    long startTime = clock.currentTimeMillis();
+    delegate.add(data, offset, count);
+    if (writeStatsConsumer != null) {
+      writeStatsConsumer.accept(count, clock.currentTimeMillis() - startTime);
+    }
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return delegate.isEmpty();
+  }
+
+  @Override
+  @Nullable
+  public byte[] peek() throws IOException {
+    return delegate.peek();
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<byte[]> iterator() {
+    return delegate.iterator();
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public long storageBytes() {
+    try {
+      return (long) fileLength.get(delegate);
+    } catch (IllegalAccessException e) {
+      return 0;
+    }
+  }
+
+  @Override
+  public long usedBytes() {
+    try {
+      return (long) usedBytes.invoke(delegate);
+    } catch (InvocationTargetException | IllegalAccessException e) {
+      return 0;
+    }
+  }
+
+  @Override
+  public long availableBytes() {
+    return storageBytes() - usedBytes();
+  }
+
+  @Override
+  public void remove() throws IOException {
+    delegate.remove();
+  }
+
+  @Override
+  public void clear() throws IOException {
+    delegate.clear();
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/queueing/TaskQueue.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/TaskQueue.java
@@ -73,12 +73,4 @@ public interface TaskQueue<T extends DataSubmissionTask<T>> extends Iterable<T> 
    */
   @Nullable
   Long getAvailableBytes();
-
-  /**
-   * Returns the unique queue name/identifier, can be anything, like file path name for
-   * file-based queues.
-   *
-   * @return queue name.
-   */
-  String getName();
 }

--- a/proxy/src/main/java/com/wavefront/agent/queueing/TaskQueueStub.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/TaskQueueStub.java
@@ -57,11 +57,6 @@ public class TaskQueueStub<T extends DataSubmissionTask<T>> implements TaskQueue
     return null;
   }
 
-  @Override
-  public String getName() {
-    return "stub";
-  }
-
   @NotNull
   @Override
   public Iterator<T> iterator() {

--- a/proxy/src/test/java/com/wavefront/agent/data/DefaultEntityPropertiesFactoryForTesting.java
+++ b/proxy/src/test/java/com/wavefront/agent/data/DefaultEntityPropertiesFactoryForTesting.java
@@ -1,0 +1,20 @@
+package com.wavefront.agent.data;
+
+import com.wavefront.data.ReportableEntityType;
+
+/**
+ * @author vasily@wavefront.com
+ */
+public class DefaultEntityPropertiesFactoryForTesting implements EntityPropertiesFactory {
+  private final EntityProperties props = new DefaultEntityPropertiesForTesting();
+
+  @Override
+  public EntityProperties get(ReportableEntityType entityType) {
+    return props;
+  }
+
+  @Override
+  public EntityProperties.GlobalProperties getGlobalProperties() {
+    return props.getGlobalProperties();
+  }
+}

--- a/proxy/src/test/java/com/wavefront/agent/handlers/ReportSourceTagHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/handlers/ReportSourceTagHandlerTest.java
@@ -3,6 +3,7 @@ package com.wavefront.agent.handlers;
 import com.google.common.collect.ImmutableList;
 
 import com.wavefront.agent.api.APIContainer;
+import com.wavefront.agent.data.DefaultEntityPropertiesFactoryForTesting;
 import com.wavefront.agent.data.DefaultEntityPropertiesForTesting;
 import com.wavefront.agent.data.DataSubmissionTask;
 import com.wavefront.agent.data.EntityProperties;
@@ -57,18 +58,7 @@ public class ReportSourceTagHandlerTest {
     };
     newAgentId = UUID.randomUUID();
     senderTaskFactory = new SenderTaskFactoryImpl(new APIContainer(null, mockAgentAPI, null),
-        newAgentId, taskQueueFactory, null, new EntityPropertiesFactory() {
-      private final EntityProperties props = new DefaultEntityPropertiesForTesting();
-      @Override
-      public EntityProperties get(ReportableEntityType entityType) {
-        return props;
-      }
-
-      @Override
-      public EntityProperties.GlobalProperties getGlobalProperties() {
-        return props.getGlobalProperties();
-      }
-    });
+        newAgentId, taskQueueFactory, null, new DefaultEntityPropertiesFactoryForTesting());
     handlerKey = HandlerKey.of(ReportableEntityType.SOURCE_TAG, "4878");
     sourceTagHandler = new ReportSourceTagHandlerImpl(handlerKey, 10,
             senderTaskFactory.createSenderTasks(handlerKey), null, blockedLogger);

--- a/proxy/src/test/java/com/wavefront/agent/queueing/ConcurrentShardedQueueFileTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/queueing/ConcurrentShardedQueueFileTest.java
@@ -1,0 +1,128 @@
+package com.wavefront.agent.queueing;
+
+import java.io.File;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Test;
+
+import com.squareup.tape2.QueueFile;
+import com.wavefront.common.Pair;
+
+import static com.wavefront.agent.queueing.ConcurrentShardedQueueFile.incrementFileName;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author vasily@wavefront.com
+ */
+public class ConcurrentShardedQueueFileTest {
+  private static final Random RANDOM = new Random();
+
+  @Test
+  public void nextFileNameTest() {
+    assertEquals("points.2878.1_0000", incrementFileName("points.2878.1", ".spool"));
+    assertEquals("points.2878.1.spool_0000", incrementFileName("points.2878.1.spool", ".spool"));
+    assertEquals("points.2878.1.spool_0001", incrementFileName("points.2878.1.spool_0000", ".spool"));
+    assertEquals("points.2878.1.spool_0002", incrementFileName("points.2878.1.spool_0001", ".spool"));
+    assertEquals("points.2878.1.spool_000a", incrementFileName("points.2878.1.spool_0009", ".spool"));
+    assertEquals("points.2878.1.spool_0010", incrementFileName("points.2878.1.spool_000f", ".spool"));
+    assertEquals("points.2878.1.spool_0100", incrementFileName("points.2878.1.spool_00ff", ".spool"));
+    assertEquals("points.2878.1.spool_ffff", incrementFileName("points.2878.1.spool_fffe", ".spool"));
+    assertEquals("points.2878.1.spool_0000", incrementFileName("points.2878.1.spool_ffff", ".spool"));
+  }
+
+  @Test
+  public void testConcurrency() throws Exception {
+    File file = new File(File.createTempFile("proxyConcurrencyTest", null).getPath() + ".spool");
+    ConcurrentShardedQueueFile queueFile = new ConcurrentShardedQueueFile(file.getCanonicalPath(),
+        ".spool", 1024 * 1024, s -> new TapeQueueFile(new QueueFile.Builder(new File(s)).build()));
+    Queue<Pair<Integer, Byte>> taskCheatSheet = new ArrayDeque<>();
+    System.out.println(queueFile.shards.size());
+    AtomicLong tasksGenerated = new AtomicLong();
+    AtomicLong nanosAdd = new AtomicLong();
+    AtomicLong nanosGet = new AtomicLong();
+    while (queueFile.shards.size() < 4) {
+      byte[] task = randomTask();
+      queueFile.add(task);
+      taskCheatSheet.add(Pair.of(task.length, task[0]));
+      tasksGenerated.incrementAndGet();
+    }
+    AtomicBoolean done = new AtomicBoolean(false);
+    AtomicBoolean fail = new AtomicBoolean(false);
+    Runnable addTask = () -> {
+      int delay = 0;
+      while (!done.get() && !fail.get()) {
+        try {
+          byte[] task = randomTask();
+          long start = System.nanoTime();
+          queueFile.add(task);
+          nanosAdd.addAndGet(System.nanoTime() - start);
+          taskCheatSheet.add(Pair.of(task.length, task[0]));
+          tasksGenerated.incrementAndGet();
+          Thread.sleep(delay / 1000);
+          delay++;
+        } catch (Exception e) {
+          e.printStackTrace();
+          fail.set(true);
+        }
+      }
+    };
+    Runnable getTask = () -> {
+      int delay = 2000;
+      while (!taskCheatSheet.isEmpty() && !fail.get()) {
+        try {
+          long start = System.nanoTime();
+          Pair<Integer, Byte> taskData = taskCheatSheet.remove();
+          byte[] task = queueFile.peek();
+          queueFile.remove();
+          nanosGet.addAndGet(System.nanoTime() - start);
+          if (taskData._1 != task.length) {
+            System.out.println("Data integrity fail! Expected: " + taskData._1 +
+                    " bytes, got " + task.length + " bytes");
+            fail.set(true);
+          }
+          for (byte b : task) {
+            if (taskData._2 != b) {
+              System.out.println("Data integrity fail! Expected " + taskData._2 + ", got " + b);
+              fail.set(true);
+            }
+          }
+          Thread.sleep(delay / 500);
+          if (delay > 0) delay--;
+        } catch (Exception e) {
+          e.printStackTrace();
+          fail.set(true);
+        }
+      }
+      done.set(true);
+    };
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    long start = System.nanoTime();
+    Future<?> addFuture = executor.submit(addTask);
+    Future<?> getFuture = executor.submit(getTask);
+    addFuture.get();
+    getFuture.get();
+    assertFalse(fail.get());
+    System.out.println("Tasks generated: " + tasksGenerated.get());
+    System.out.println("Real time (ms) = " + (System.nanoTime() - start) / 1_000_000);
+    System.out.println("Add + remove time (ms) = " + (nanosGet.get() + nanosAdd.get()) / 1_000_000);
+    System.out.println("Add time (ms) = " + nanosAdd.get() / 1_000_000);
+    System.out.println("Remove time (ms) = " + nanosGet.get() / 1_000_000);
+  }
+
+  private byte[] randomTask() {
+    int size = RANDOM.nextInt(32 * 1024) + 1;
+    byte[] result = new byte[size];
+    RANDOM.nextBytes(result);
+    Arrays.fill(result, result[0]);
+    return result;
+  }
+}

--- a/proxy/src/test/java/com/wavefront/agent/queueing/InstrumentedTaskQueueDelegateTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/queueing/InstrumentedTaskQueueDelegateTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @author vasily@wavefront.com
  */
-public class SynchronizedTaskQueueWithMetricsTest {
+public class InstrumentedTaskQueueDelegateTest {
 
   @Test
   public void testLineDelimitedTask() throws Exception {
@@ -110,10 +110,10 @@ public class SynchronizedTaskQueueWithMetricsTest {
 
   private <T extends DataSubmissionTask<T>> TaskQueue<T> getTaskQueue(
       File file, RetryTaskConverter.CompressionType compressionType) throws Exception {
-    return new SynchronizedTaskQueueWithMetrics<>(new FileBasedTaskQueue<>(
-        new QueueFile.Builder(file).build(),
-        new RetryTaskConverter<T>("2878",
-            compressionType)),
+    return new InstrumentedTaskQueueDelegate<>(new FileBasedTaskQueue<>(
+        new ConcurrentShardedQueueFile(file.getCanonicalPath(), ".spool", 16 * 1024,
+            s -> new TapeQueueFile(new QueueFile.Builder(new File(s)).build())),
+        new RetryTaskConverter<T>("2878", compressionType)),
         null, null, null);
   }
 }


### PR DESCRIPTION
Instead of doubling the size of a buffer file every time we need to grow it, maintain a collection of smaller shards (128MB by default). 