### PR TITLE
Create new docker file specific for WF-proxy release (filename: Dockerrfile-for-release)

### DIFF
--- a/proxy/docker/Dockerfile-for-release
+++ b/proxy/docker/Dockerfile-for-release
@@ -1,0 +1,37 @@
+FROM photon:3.0
+
+# This script may automatically configure wavefront without prompting, based on
+# these variables:
+#  WAVEFRONT_URL           (required)
+#  WAVEFRONT_TOKEN         (required)
+#  JAVA_HEAP_USAGE         (default is 4G)
+#  WAVEFRONT_HOSTNAME      (default is the docker containers hostname)
+#  WAVEFRONT_PROXY_ARGS    (default is none)
+#  JAVA_ARGS               (default is none)
+
+RUN tdnf install -y \
+  openjdk11 \
+  shadow
+
+# Add new group:user "wavefront"
+RUN /usr/sbin/groupadd -g 2000 wavefront
+RUN useradd --comment '' --uid 1000 --gid 2000 wavefront
+RUN chown -R wavefront:wavefront /var
+RUN chmod 755 /var
+
+########### specific lines for Jenkins release process ############
+# replace "wf-proxy" download section to "copy the upstream Jenkins artifact"
+COPY wavefront-proxy*.deb /
+RUN dpkg -x /wavefront-proxy*.deb /
+
+ENV PATH /usr/lib/jvm/OpenJDK-1.11.0/bin/:$PATH
+
+# Run the agent
+EXPOSE 3878
+EXPOSE 2878
+EXPOSE 4242
+
+USER 1000:2000
+
+ADD run.sh run.sh
+CMD ["/bin/bash", "/run.sh"]


### PR DESCRIPTION
When we create WF-Proxy / proxy-next docker images for release, we need to replace the original Dockerfile's "install wf-proxy" section with lines to install the proxy from generated .deb files for the release. Until now, we were using sed commands to delete and replace specific lines to achieve this. This was not a scalable solution. Hence, we decided to move forward with creating our own Dockerfile-for-release to achieve this.