### PR TITLE
[Dockerfile-for-release]: Since we're using Photon, use tdnf to install rpm instead of using dpkg and deb

### DIFF
--- a/proxy/docker/Dockerfile-for-release
+++ b/proxy/docker/Dockerfile-for-release
@@ -21,8 +21,9 @@ RUN chmod 755 /var
 
 ########### specific lines for Jenkins release process ############
 # replace "wf-proxy" download section to "copy the upstream Jenkins artifact"
-COPY wavefront-proxy*.deb /
-RUN dpkg -x /wavefront-proxy*.deb /
+COPY wavefront-proxy*.rpm /
+RUN tdnf install -y rpm
+RUN rpm --install /wavefront-proxy*.rpm
 
 ENV PATH /usr/lib/jvm/OpenJDK-1.11.0/bin/:$PATH
 


### PR DESCRIPTION
Since we're moving to Photon OS, need to update Dockerfile-for-release to use tdnf and rpm to install wf-proxy instead of dpkg and deb