### PR TITLE
[Dockerfile-for-release]: copy log4j.xml to /etc/wavefront/wavefront-proxy

### DIFF
--- a/proxy/docker/Dockerfile-for-release
+++ b/proxy/docker/Dockerfile-for-release
@@ -21,8 +21,9 @@ RUN chmod 755 /var
 
 ########### specific lines for Jenkins release process ############
 # replace "wf-proxy" download section to "copy the upstream Jenkins artifact"
-COPY wavefront-proxy*.deb /
-RUN dpkg -x /wavefront-proxy*.deb /
+COPY wavefront-proxy*.rpm /
+RUN tdnf install -y rpm
+RUN rpm --install /wavefront-proxy*.rpm
 
 ENV PATH /usr/lib/jvm/OpenJDK-1.11.0/bin/:$PATH
 

--- a/proxy/docker/Dockerfile-for-release
+++ b/proxy/docker/Dockerfile-for-release
@@ -24,6 +24,7 @@ RUN chmod 755 /var
 COPY wavefront-proxy*.rpm /
 RUN tdnf install -y rpm
 RUN rpm --install /wavefront-proxy*.rpm
+RUN cp /etc/wavefront/wavefront-proxy/log4j2-stdout.xml.default /etc/wavefront/wavefront-proxy/log4j2.xml
 
 ENV PATH /usr/lib/jvm/OpenJDK-1.11.0/bin/:$PATH
 


### PR DESCRIPTION
Add the line from original Dockerfile which copies log4j.xml to /etc/wavefront/wavefront-proxy 