### PR TITLE
Lib version upgrades. Updating libs : thrift  0.14.1.   netty version…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
   <properties>
     <!-- jdk 11 can be used for building -->
     <jdk.version>11</jdk.version>
-    
+
     <!-- Force encoding to UTF-8 (bug in OS X)-->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -58,7 +58,7 @@
     <log4j.version>2.13.3</log4j.version>
     <jackson.version>2.11.0</jackson.version>
     <jackson-databind.version>2.11.0</jackson-databind.version>
-    <netty.version>4.1.53.Final</netty.version>
+    <netty.version>4.1.60.Final</netty.version>
     <java-lib.version>2020-12.1</java-lib.version>
 
     <doclint>none</doclint>
@@ -154,7 +154,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.12</version>
+        <version>4.5.13</version>
       </dependency>
       <dependency>
         <groupId>org.ops4j.pax.url</groupId>
@@ -248,11 +248,6 @@
         <artifactId>netty-transport-native-epoll</artifactId>
         <version>${netty.version}</version>
         <classifier>linux-x86_64</classifier>
-      </dependency>
-      <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>1.4.13-java7</version>
       </dependency>
       <dependency>
         <groupId>com.rubiconproject.oss</groupId>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -55,6 +55,12 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
       <version>1.29.0</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -85,7 +91,7 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-      <version>0.13.0</version>
+      <version>0.14.1</version>
     </dependency>
     <dependency>
       <groupId>io.zipkin.zipkin2</groupId>
@@ -99,10 +105,6 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -150,6 +152,10 @@
         <exclusion>
           <groupId>com.sun.java</groupId>
           <artifactId>tools</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.thoughtworks.xstream</groupId>
+          <artifactId>xstream</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
… to 4.1.60.Final. httpclient to 4.5.13. Removing xstream since it does not seem to be used in the compilation.