### PR TITLE
NPE fix for FileBasedTaskQueue (#617)

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/queueing/FileBasedTaskQueue.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/FileBasedTaskQueue.java
@@ -83,9 +83,11 @@ public class FileBasedTaskQueue<T extends DataSubmissionTask<T>> implements Task
       this.head = taskConverter.fromBytes(task);
     }
     queueFile.remove();
-    int weight = this.head.weight();
-    currentWeight.getAndUpdate(x -> x > weight ? x - weight : 0);
-    this.head = null;
+    if(this.head != null) {
+      int weight = this.head.weight();
+      currentWeight.getAndUpdate(x -> x > weight ? x - weight : 0);
+      this.head = null;
+    }
   }
 
   @Override


### PR DESCRIPTION
* Lib version upgrades. Updating libs : thrift  0.14.1.   netty version to 4.1.60.Final. httpclient to 4.5.13. Removing xstream since it does not seem to be used in the compilation.

* 1. Excluding guava from protubuf to avoid pulling in a bad version. 2. Adding exclusion of xstream dependency pulled.

* doing a null check for weight before initializing weight

* removing unnecessary variables