### PR TITLE
ESO-3192 fix pip/setuptools vulnerabilities in wf-proxy docker image

### DIFF
--- a/proxy/docker/Dockerfile-for-release
+++ b/proxy/docker/Dockerfile-for-release
@@ -22,8 +22,8 @@ RUN chmod 755 /var
 ########### specific lines for Jenkins release process ############
 # replace "wf-proxy" download section to "copy the upstream Jenkins artifact"
 COPY wavefront-proxy*.rpm /
-RUN tdnf install -y rpm
-RUN rpm --install /wavefront-proxy*.rpm
+RUN tdnf install -y yum
+RUN yum install -y /wavefront-proxy*.rpm
 RUN cp /etc/wavefront/wavefront-proxy/log4j2-stdout.xml.default /etc/wavefront/wavefront-proxy/log4j2.xml
 
 ENV PATH /usr/lib/jvm/OpenJDK-1.11.0/bin/:$PATH


### PR DESCRIPTION
Remove dependency on pip/setuptools for creating docker image due to vulnerabilities.
(ESO-3192)[https://wavefront.atlassian.net/browse/ESO-3192]