### PR TITLE
ESO-3233: Fix Dockerfile by installing curl in master branch

### DIFF
--- a/proxy/docker/Dockerfile
+++ b/proxy/docker/Dockerfile
@@ -11,7 +11,8 @@ FROM photon:3.0
 
 RUN tdnf install -y \
   openjdk11 \
-  shadow
+  shadow \
+  curl
 
 # Add new group:user "wavefront"
 RUN /usr/sbin/groupadd -g 2000 wavefront


### PR DESCRIPTION
Hit an error during GAing `10.6` due to curl.
Install curl in Dockerfile for the fix, and merge the fix to master branch!