### PR TITLE
Multiple fixes related to 10.7 GA

### DIFF
--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -4,7 +4,7 @@ FROM centos:7
 RUN yum -y install gcc make autoconf wget vim rpm-build git gpg2
 
 # Set up Ruby 2.0.0 for FPM 1.10.0
-RUN gpg2 --homedir /root/.gnupg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --homedir /root/.gnupg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN curl -L get.rvm.io | bash -s stable
 ENV PATH /usr/local/rvm/gems/ruby-2.0.0-p598/bin:/usr/local/rvm/gems/ruby-2.0.0-p598@global/bin:/usr/local/rvm/rubies/ruby-2.0.0-p598/bin:/usr/local/rvm/bin:$PATH
 ENV LC_ALL en_US.UTF-8

--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -4,7 +4,7 @@ FROM centos:7
 RUN yum -y install gcc make autoconf wget vim rpm-build git gpg2
 
 # Set up Ruby 2.0.0 for FPM 1.10.0
-RUN gpg2 --homedir /root/.gnupg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --homedir /root/.gnupg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN curl -L get.rvm.io | bash -s stable
 ENV PATH /usr/local/rvm/gems/ruby-2.0.0-p598/bin:/usr/local/rvm/gems/ruby-2.0.0-p598@global/bin:/usr/local/rvm/rubies/ruby-2.0.0-p598/bin:/usr/local/rvm/bin:$PATH
 ENV LC_ALL en_US.UTF-8

--- a/proxy/docker/Dockerfile
+++ b/proxy/docker/Dockerfile
@@ -11,7 +11,8 @@ FROM photon:3.0
 
 RUN tdnf install -y \
   openjdk11 \
-  shadow
+  shadow \
+  curl
 
 # Add new group:user "wavefront"
 RUN /usr/sbin/groupadd -g 2000 wavefront

--- a/proxy/docker/Dockerfile-for-release
+++ b/proxy/docker/Dockerfile-for-release
@@ -22,8 +22,8 @@ RUN chmod 755 /var
 ########### specific lines for Jenkins release process ############
 # replace "wf-proxy" download section to "copy the upstream Jenkins artifact"
 COPY wavefront-proxy*.rpm /
-RUN tdnf install -y rpm
-RUN rpm --install /wavefront-proxy*.rpm
+RUN tdnf install -y yum
+RUN yum install -y /wavefront-proxy*.rpm
 RUN cp /etc/wavefront/wavefront-proxy/log4j2-stdout.xml.default /etc/wavefront/wavefront-proxy/log4j2.xml
 
 ENV PATH /usr/lib/jvm/OpenJDK-1.11.0/bin/:$PATH


### PR DESCRIPTION
- ESO:3222: change gpg keyserver from hkp://keys.gnupg.net to keyserver.ubuntu.com
- ESO:3233: install curl in Dockerfile
- ESO-3192: fix pip/setuptools vulnerabilities in wf-proxy docker image created during the release