### PR TITLE
Multicasting - xiaochenw/monit 25479

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/ProxyConfig.java
+++ b/proxy/src/main/java/com/wavefront/agent/ProxyConfig.java
@@ -1,19 +1,24 @@
 package com.wavefront.agent;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.google.common.collect.Iterables;
+import com.wavefront.agent.api.APIContainer;
 import com.wavefront.agent.auth.TokenValidationMethod;
 import com.wavefront.agent.config.Configuration;
 import com.wavefront.agent.config.ReportableConfig;
 import com.wavefront.agent.data.TaskQueueLevel;
 import com.wavefront.common.TimeProvider;
+
 import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.ArrayList;
@@ -38,9 +43,8 @@ import static com.wavefront.agent.data.EntityProperties.DEFAULT_MIN_SPLIT_BATCH_
 import static com.wavefront.agent.data.EntityProperties.DEFAULT_RETRY_BACKOFF_BASE_SECONDS;
 import static com.wavefront.agent.data.EntityProperties.DEFAULT_SPLIT_PUSH_WHEN_RATE_LIMITED;
 import static com.wavefront.agent.data.EntityProperties.NO_RATE_LIMIT;
-import static com.wavefront.common.Utils.getLocalHostName;
 import static com.wavefront.common.Utils.getBuildVersion;
-
+import static com.wavefront.common.Utils.getLocalHostName;
 import static io.opentracing.tag.Tags.SPAN_KIND;
 
 /**
@@ -816,6 +820,14 @@ public class ProxyConfig extends Configuration {
       "requests. Default: false")
   protected boolean corsAllowNullOrigin = false;
 
+  @Parameter(names = {"--multicastingTenants"}, description = "The number of tenants to data " +
+      "points" +
+      " multicasting. Default: 0")
+  protected int multicastingTenants = 0;
+  // the multicasting tenant list is parsed separately
+  // {tenant_name : {"token": <wf_token>, "server": <wf_sever_url>}}
+  protected Map<String, Map<String, String>> multicastingTenantList = Maps.newHashMap();
+
   @Parameter()
   List<String> unparsed_params;
 
@@ -1563,6 +1575,14 @@ public class ProxyConfig extends Configuration {
     return trafficShapingHeadroom;
   }
 
+  public int getMulticastingTenants() {
+    return multicastingTenants;
+  }
+
+  public Map<String, Map<String, String>> getMulticastingTenantList() {
+    return multicastingTenantList;
+  }
+
   public List<String> getCorsEnabledPorts() {
     return Splitter.on(",").trimResults().omitEmptyStrings().splitToList(corsEnabledPorts);
   }
@@ -1892,6 +1912,25 @@ public class ProxyConfig extends Configuration {
           httpHealthCheckFailStatusCode);
       httpHealthCheckFailResponseBody = config.getString("httpHealthCheckFailResponseBody",
           httpHealthCheckFailResponseBody);
+
+      // Multicasting configurations
+      multicastingTenantList.put(APIContainer.CENTRAL_TENANT_NAME,
+          ImmutableMap.of(APIContainer.API_SERVER, server, APIContainer.API_TOKEN, token));
+      multicastingTenants = config.getInteger("multicastingTenants", multicastingTenants);
+      String tenantName;
+      String tenantServer;
+      String tenantToken;
+      for (int i = 1; i <= multicastingTenants; i++) {
+        tenantName = config.getString(String.format("multicastingTenantName_%d", i), "");
+        if (tenantName.equals(APIContainer.CENTRAL_TENANT_NAME)) {
+          throw new IllegalArgumentException("Error in multicasting endpoints initiation: " +
+              "\"central\" is the reserved tenant name.");
+        }
+        tenantServer = config.getString(String.format("multicastingServer_%d", i), "");
+        tenantToken = config.getString(String.format("multicastingToken_%d", i), "");
+        multicastingTenantList.put(tenantName, ImmutableMap.of(APIContainer.API_SERVER, tenantServer,
+            APIContainer.API_TOKEN, tenantToken));
+      }
 
       // TLS configurations
       privateCertPath = config.getString("privateCertPath", privateCertPath);

--- a/proxy/src/main/java/com/wavefront/agent/api/APIContainer.java
+++ b/proxy/src/main/java/com/wavefront/agent/api/APIContainer.java
@@ -1,6 +1,8 @@
 package com.wavefront.agent.api;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+
 import com.wavefront.agent.JsonNodeWriter;
 import com.wavefront.agent.SSLConnectionSocketFactoryImpl;
 import com.wavefront.agent.channel.DisableGZIPEncodingInterceptor;
@@ -31,6 +33,8 @@ import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.ext.WriterInterceptor;
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
+import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -39,13 +43,17 @@ import java.util.concurrent.TimeUnit;
  * @author vasily@wavefront.com
  */
 public class APIContainer {
+  public final static String CENTRAL_TENANT_NAME = "central";
+  public final static String API_SERVER = "server";
+  public final static String API_TOKEN = "token";
+
   private final ProxyConfig proxyConfig;
   private final ResteasyProviderFactory resteasyProviderFactory;
   private final ClientHttpEngine clientHttpEngine;
   private final boolean discardData;
-  private ProxyV2API proxyV2API;
-  private SourceTagAPI sourceTagAPI;
-  private EventAPI eventAPI;
+  private Map<String, ProxyV2API> proxyV2APIsForMulticasting;
+  private Map<String, SourceTagAPI> sourceTagAPIsForMulticasting;
+  private Map<String, EventAPI> eventAPIsForMulticasting;
 
   /**
    * @param proxyConfig proxy configuration settings
@@ -56,13 +64,31 @@ public class APIContainer {
     this.resteasyProviderFactory = createProviderFactory();
     this.clientHttpEngine = createHttpEngine();
     this.discardData = discardData;
-    this.proxyV2API = createService(proxyConfig.getServer(), ProxyV2API.class);
-    this.sourceTagAPI = createService(proxyConfig.getServer(), SourceTagAPI.class);
-    this.eventAPI = createService(proxyConfig.getServer(), EventAPI.class);
+
+    // config the multicasting tenants / clusters
+    proxyV2APIsForMulticasting = Maps.newHashMap();
+    sourceTagAPIsForMulticasting = Maps.newHashMap();
+    eventAPIsForMulticasting = Maps.newHashMap();
+    // tenantInfo: {<tenant_name> : {"token": <wf_token>, "server": <wf_sever_url>}}
+    String tenantName;
+    String tenantServer;
+    for (Map.Entry<String, Map<String, String>> tenantInfo:
+        proxyConfig.getMulticastingTenantList().entrySet()) {
+      tenantName = tenantInfo.getKey();
+      tenantServer = tenantInfo.getValue().get(API_SERVER);
+      proxyV2APIsForMulticasting.put(tenantName, createService(tenantServer, ProxyV2API.class));
+      sourceTagAPIsForMulticasting.put(tenantName, createService(tenantServer, SourceTagAPI.class));
+      eventAPIsForMulticasting.put(tenantName, createService(tenantServer, EventAPI.class));
+    }
+
     if (discardData) {
-      this.proxyV2API = new NoopProxyV2API(proxyV2API);
-      this.sourceTagAPI = new NoopSourceTagAPI();
-      this.eventAPI = new NoopEventAPI();
+      ProxyV2API proxyV2API = this.proxyV2APIsForMulticasting.get(CENTRAL_TENANT_NAME);
+      this.proxyV2APIsForMulticasting = Maps.newHashMap();
+      this.proxyV2APIsForMulticasting.put(CENTRAL_TENANT_NAME, new NoopProxyV2API(proxyV2API));
+      this.sourceTagAPIsForMulticasting = Maps.newHashMap();
+      this.sourceTagAPIsForMulticasting.put(CENTRAL_TENANT_NAME, new NoopSourceTagAPI());
+      this.eventAPIsForMulticasting = Maps.newHashMap();
+      this.eventAPIsForMulticasting.put(CENTRAL_TENANT_NAME, new NoopEventAPI());
     }
     configureHttpProxy();
   }
@@ -80,54 +106,73 @@ public class APIContainer {
     this.resteasyProviderFactory = null;
     this.clientHttpEngine = null;
     this.discardData = false;
-    this.proxyV2API = proxyV2API;
-    this.sourceTagAPI = sourceTagAPI;
-    this.eventAPI = eventAPI;
+    proxyV2APIsForMulticasting = Maps.newHashMap();
+    proxyV2APIsForMulticasting.put(CENTRAL_TENANT_NAME, proxyV2API);
+    sourceTagAPIsForMulticasting = Maps.newHashMap();
+    sourceTagAPIsForMulticasting.put(CENTRAL_TENANT_NAME, sourceTagAPI);
+    eventAPIsForMulticasting = Maps.newHashMap();
+    eventAPIsForMulticasting.put(CENTRAL_TENANT_NAME, eventAPI);
   }
 
   /**
-   * Get RESTeasy proxy for {@link ProxyV2API}.
-   *
-   * @return proxy object
+   * Provide the collection of loaded tenant name list
+   * @return tenant name collection
    */
-  public ProxyV2API getProxyV2API() {
-    return proxyV2API;
+  public Collection<String> getTenantNameList() {
+    return proxyV2APIsForMulticasting.keySet();
   }
 
   /**
-   * Get RESTeasy proxy for {@link SourceTagAPI}.
+   * Get RESTeasy proxy for {@link ProxyV2API} with given tenant name.
    *
-   * @return proxy object
+   * @param tenantName tenant name
+   * @return proxy object corresponding to tenant
    */
-  public SourceTagAPI getSourceTagAPI() {
-    return sourceTagAPI;
+  public ProxyV2API getProxyV2APIForTenant(String tenantName) {
+    return proxyV2APIsForMulticasting.get(tenantName);
   }
 
   /**
-   * Get RESTeasy proxy for {@link EventAPI}.
+   * Get RESTeasy proxy for {@link SourceTagAPI} with given tenant name.
    *
-   * @return proxy object
+   * @param tenantName tenant name
+   * @return proxy object corresponding to the tenant name
    */
-  public EventAPI getEventAPI() {
-    return eventAPI;
+  public SourceTagAPI getSourceTagAPIForTenant(String tenantName) {
+    return sourceTagAPIsForMulticasting.get(tenantName);
+  }
+
+  /**
+   * Get RESTeasy proxy for {@link EventAPI} with given tenant name.
+   * @param tenantName tenant name
+   * @return proxy object corresponding to the tenant name
+   */
+  public EventAPI getEventAPIForTenant(String tenantName) {
+    return eventAPIsForMulticasting.get(tenantName);
   }
 
   /**
    * Re-create RESTeasy proxies with new server endpoint URL (allows changing URL at runtime).
    *
+   * @param tenantName the tenant to be updated
    * @param serverEndpointUrl new server endpoint URL.
    */
-  public void updateServerEndpointURL(String serverEndpointUrl) {
+  public void updateServerEndpointURL(String tenantName, String serverEndpointUrl) {
     if (proxyConfig == null) {
       throw new IllegalStateException("Can't invoke updateServerEndpointURL with this constructor");
     }
-    this.proxyV2API = createService(serverEndpointUrl, ProxyV2API.class);
-    this.sourceTagAPI = createService(serverEndpointUrl, SourceTagAPI.class);
-    this.eventAPI = createService(serverEndpointUrl, EventAPI.class);
+    proxyV2APIsForMulticasting.put(tenantName, createService(serverEndpointUrl, ProxyV2API.class));
+    sourceTagAPIsForMulticasting.put(tenantName, createService(serverEndpointUrl, SourceTagAPI.class));
+    eventAPIsForMulticasting.put(tenantName, createService(serverEndpointUrl, EventAPI.class));
+
     if (discardData) {
-      this.proxyV2API = new NoopProxyV2API(proxyV2API);
-      this.sourceTagAPI = new NoopSourceTagAPI();
-      this.eventAPI = new NoopEventAPI();
+      ProxyV2API proxyV2API = this.proxyV2APIsForMulticasting.get(CENTRAL_TENANT_NAME);
+      this.proxyV2APIsForMulticasting = Maps.newHashMap();
+      this.proxyV2APIsForMulticasting.put(CENTRAL_TENANT_NAME, new NoopProxyV2API(proxyV2API));
+      this.sourceTagAPIsForMulticasting = Maps.newHashMap();
+      this.sourceTagAPIsForMulticasting.put(CENTRAL_TENANT_NAME, new NoopSourceTagAPI());
+      this.eventAPIsForMulticasting = Maps.newHashMap();
+      this.eventAPIsForMulticasting.put(CENTRAL_TENANT_NAME, new NoopEventAPI());
     }
   }
 

--- a/proxy/src/main/java/com/wavefront/agent/handlers/EventHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/EventHandlerImpl.java
@@ -1,12 +1,16 @@
 package com.wavefront.agent.handlers;
 
 import com.google.common.annotations.VisibleForTesting;
+
+import com.wavefront.agent.api.APIContainer;
 import com.wavefront.data.Validation;
 import com.wavefront.dto.Event;
 import wavefront.report.ReportEvent;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -29,17 +33,18 @@ public class EventHandlerImpl extends AbstractReportableEntityHandler<ReportEven
    * @param handlerKey           pipeline key.
    * @param blockedItemsPerBatch number of blocked items that are allowed to be written into the
    *                             main log.
-   * @param senderTasks          sender tasks.
+   * @param senderTaskMap        map of tenant name and tasks actually handling data transfer to
+   *                             the Wavefront endpoint corresponding to the tenant name
    * @param receivedRateSink     where to report received rate.
    * @param blockedEventsLogger  logger for blocked events.
    * @param validEventsLogger    logger for valid events.
    */
   public EventHandlerImpl(final HandlerKey handlerKey, final int blockedItemsPerBatch,
-                          @Nullable final Collection<SenderTask<Event>> senderTasks,
-                          @Nullable final Consumer<Long> receivedRateSink,
+                          @Nullable final Map<String, Collection<SenderTask<Event>>> senderTaskMap,
+                          @Nullable final BiConsumer<String, Long> receivedRateSink,
                           @Nullable final Logger blockedEventsLogger,
                           @Nullable final Logger validEventsLogger) {
-    super(handlerKey, blockedItemsPerBatch, EVENT_SERIALIZER, senderTasks, true, receivedRateSink,
+    super(handlerKey, blockedItemsPerBatch, EVENT_SERIALIZER, senderTaskMap, true, receivedRateSink,
         blockedEventsLogger);
     this.validItemsLogger = validEventsLogger;
   }
@@ -49,8 +54,22 @@ public class EventHandlerImpl extends AbstractReportableEntityHandler<ReportEven
     if (!annotationKeysAreValid(event)) {
       throw new IllegalArgumentException("WF-401: Event annotation key has illegal characters.");
     }
-    getTask().add(new Event(event));
+    Event eventToAdd = new Event(event);
+    getTask(APIContainer.CENTRAL_TENANT_NAME).add(eventToAdd);
     getReceivedCounter().inc();
+    // check if event annotations contains the tag key indicating this event should be multicasted
+    if (isMulticastingActive && event.getAnnotations() != null &&
+        event.getAnnotations().containsKey(MULTICASTING_TENANT_TAG_KEY)) {
+      String[] multicastingTenantNames =
+          event.getAnnotations().get(MULTICASTING_TENANT_TAG_KEY).trim().split(",");
+      event.getAnnotations().remove(MULTICASTING_TENANT_TAG_KEY);
+      for (String multicastingTenantName : multicastingTenantNames) {
+        // if the tenant name indicated in event tag is not configured, just ignore
+        if (getTask(multicastingTenantName) != null) {
+          getTask(multicastingTenantName).add(new Event(event));
+        }
+      }
+    }
     if (validItemsLogger != null && validItemsLogger.isLoggable(Level.FINEST)) {
       validItemsLogger.info(EVENT_SERIALIZER.apply(event));
     }

--- a/proxy/src/main/java/com/wavefront/agent/handlers/HandlerKey.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/HandlerKey.java
@@ -3,10 +3,13 @@ package com.wavefront.agent.handlers;
 import com.wavefront.data.ReportableEntityType;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import java.util.Objects;
 
 /**
- * An immutable unique identifier for a handler pipeline (type of objects handled + port/handle name)
+ * An immutable unique identifier for a handler pipeline (type of objects handled + port/handle
+ * name + tenant name)
  *
  * @author vasily@wavefront.com
  */
@@ -14,10 +17,17 @@ public class HandlerKey {
   private final ReportableEntityType entityType;
   @Nonnull
   private final String handle;
+  @Nullable
+  private final String tenantName;
 
-  private HandlerKey(ReportableEntityType entityType, @Nonnull String handle) {
+  private HandlerKey(ReportableEntityType entityType, @Nonnull String handle, @Nullable String tenantName) {
     this.entityType = entityType;
     this.handle = handle;
+    this.tenantName = tenantName;
+  }
+
+  public static String generateTenantSpecificHandle(String handle, @Nonnull String tenantName) {
+    return handle + "." + tenantName;
   }
 
   public ReportableEntityType getEntityType() {
@@ -26,16 +36,26 @@ public class HandlerKey {
 
   @Nonnull
   public String getHandle() {
-    return handle;
+    return handle + (this.tenantName == null ? "" : "." + this.tenantName);
+  }
+
+  public String getTenantName() {
+    return this.tenantName;
   }
 
   public static HandlerKey of(ReportableEntityType entityType, @Nonnull String handle) {
-    return new HandlerKey(entityType, handle);
+    return new HandlerKey(entityType, handle, null);
+  }
+
+  public static HandlerKey of(ReportableEntityType entityType, @Nonnull String handle,
+                              @Nonnull String tenantName) {
+    return new HandlerKey(entityType, handle, tenantName);
   }
 
   @Override
   public int hashCode() {
-    return 31 * entityType.hashCode() + handle.hashCode();
+    return 31 * 31 * entityType.hashCode() + 31 * handle.hashCode() + (this.tenantName == null ?
+        0 : this.tenantName.hashCode());
   }
 
   @Override
@@ -45,11 +65,12 @@ public class HandlerKey {
     HandlerKey that = (HandlerKey) o;
     if (!entityType.equals(that.entityType)) return false;
     if (!Objects.equals(handle, that.handle)) return false;
+    if (!Objects.equals(tenantName, that.tenantName)) return false;
     return true;
   }
 
   @Override
   public String toString() {
-    return this.entityType + "." + this.handle;
+    return this.entityType + "." + this.handle + (this.tenantName == null ? "" : "." + this.tenantName);
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/handlers/HistogramAccumulationHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/HistogramAccumulationHandlerImpl.java
@@ -13,6 +13,8 @@ import wavefront.report.ReportPoint;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -57,7 +59,7 @@ public class HistogramAccumulationHandlerImpl extends ReportPointHandlerImpl {
                                           @Nullable Granularity granularity,
                                           @Nonnull final ValidationConfiguration validationConfig,
                                           boolean isHistogramInput,
-                                          @Nullable final Consumer<Long> receivedRateSink,
+                                          @Nullable final BiConsumer<String, Long> receivedRateSink,
                                           @Nullable final Logger blockedItemLogger,
                                           @Nullable final Logger validItemsLogger) {
     super(handlerKey, blockedItemsPerBatch, null, validationConfig, !isHistogramInput,

--- a/proxy/src/main/java/com/wavefront/agent/handlers/ReportableEntityHandlerFactoryImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/ReportableEntityHandlerFactoryImpl.java
@@ -1,5 +1,6 @@
 package com.wavefront.agent.handlers;
 
+import com.wavefront.agent.api.APIContainer;
 import com.wavefront.agent.data.EntityPropertiesFactory;
 import com.wavefront.api.agent.ValidationConfiguration;
 import com.wavefront.common.Utils;
@@ -10,6 +11,7 @@ import org.apache.commons.lang.math.NumberUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.Logger;
@@ -59,7 +61,7 @@ public class ReportableEntityHandlerFactoryImpl implements ReportableEntityHandl
   private final Logger blockedHistogramsLogger;
   private final Logger blockedSpansLogger;
   private final Function<Histogram, Histogram> histogramRecompressor;
-  private final EntityPropertiesFactory entityPropertiesFactory;
+  private final Map<String, EntityPropertiesFactory> entityPropsFactoryMap;
 
   /**
    * Create new instance.
@@ -75,7 +77,7 @@ public class ReportableEntityHandlerFactoryImpl implements ReportableEntityHandl
       @Nonnull final ValidationConfiguration validationConfig, final Logger blockedPointsLogger,
       final Logger blockedHistogramsLogger, final Logger blockedSpansLogger,
       @Nullable Function<Histogram, Histogram> histogramRecompressor,
-      EntityPropertiesFactory entityPropertiesFactory) {
+      final Map<String, EntityPropertiesFactory> entityPropsFactoryMap) {
     this.senderTaskFactory = senderTaskFactory;
     this.blockedItemsPerBatch = blockedItemsPerBatch;
     this.validationConfig = validationConfig;
@@ -83,14 +85,14 @@ public class ReportableEntityHandlerFactoryImpl implements ReportableEntityHandl
     this.blockedHistogramsLogger = blockedHistogramsLogger;
     this.blockedSpansLogger = blockedSpansLogger;
     this.histogramRecompressor = histogramRecompressor;
-    this.entityPropertiesFactory = entityPropertiesFactory;
+    this.entityPropsFactoryMap = entityPropsFactoryMap;
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public <T, U> ReportableEntityHandler<T, U> getHandler(HandlerKey handlerKey) {
-    Consumer<Long> receivedRateSink = rate ->
-        entityPropertiesFactory.get(handlerKey.getEntityType()).
+    BiConsumer<String, Long> receivedRateSink = (tenantName, rate) ->
+        entityPropsFactoryMap.get(tenantName).get(handlerKey.getEntityType()).
             reportReceivedRate(handlerKey.getHandle(), rate);
     return (ReportableEntityHandler<T, U>) handlers.computeIfAbsent(handlerKey.getHandle(),
         h -> new ConcurrentHashMap<>()).computeIfAbsent(handlerKey.getEntityType(), k -> {
@@ -112,7 +114,7 @@ public class ReportableEntityHandlerFactoryImpl implements ReportableEntityHandl
           return new SpanHandlerImpl(handlerKey, blockedItemsPerBatch,
               senderTaskFactory.createSenderTasks(handlerKey),
               validationConfig, receivedRateSink, blockedSpansLogger, VALID_SPANS_LOGGER,
-              () -> entityPropertiesFactory.getGlobalProperties().getDropSpansDelayedMinutes(),
+              (tenantName) -> entityPropsFactoryMap.get(tenantName).getGlobalProperties().getDropSpansDelayedMinutes(),
               Utils.lazySupplier(() -> getHandler(HandlerKey.of(TRACE_SPAN_LOGS,
                   handlerKey.getHandle()))));
         case TRACE_SPAN_LOGS:

--- a/proxy/src/main/java/com/wavefront/agent/handlers/SenderTaskFactory.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/SenderTaskFactory.java
@@ -3,6 +3,7 @@ package com.wavefront.agent.handlers;
 import com.wavefront.agent.data.QueueingReason;
 
 import java.util.Collection;
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -18,9 +19,9 @@ public interface SenderTaskFactory {
    * Create a collection of {@link SenderTask objects} for a specified handler key.
    *
    * @param handlerKey unique identifier for the handler.
-   * @return created tasks.
+   * @return created tasks corresponding to different Wavefront endpoints {@link com.wavefront.api.ProxyV2API}.
    */
-  <T> Collection<SenderTask<T>> createSenderTasks(@Nonnull HandlerKey handlerKey);
+  <T> Map<String, Collection<SenderTask<T>>> createSenderTasks(@Nonnull HandlerKey handlerKey);
 
   /**
    * Shut down all tasks.

--- a/proxy/src/main/java/com/wavefront/agent/queueing/QueueingFactoryImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/queueing/QueueingFactoryImpl.java
@@ -1,9 +1,10 @@
 package com.wavefront.agent.queueing;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import com.wavefront.agent.api.APIContainer;
-import com.wavefront.agent.data.EntityPropertiesFactory;
 import com.wavefront.agent.data.DataSubmissionTask;
+import com.wavefront.agent.data.EntityPropertiesFactory;
 import com.wavefront.agent.data.EventDataSubmissionTask;
 import com.wavefront.agent.data.LineDelimitedDataSubmissionTask;
 import com.wavefront.agent.data.SourceTagSubmissionTask;
@@ -12,7 +13,6 @@ import com.wavefront.agent.handlers.HandlerKey;
 import com.wavefront.common.NamedThreadFactory;
 import com.wavefront.data.ReportableEntityType;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -22,6 +22,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import javax.annotation.Nonnull;
 
 /**
  * A caching implementation of {@link QueueingFactory}.
@@ -37,22 +39,23 @@ public class QueueingFactoryImpl implements QueueingFactory {
   private final TaskQueueFactory taskQueueFactory;
   private final APIContainer apiContainer;
   private final UUID proxyId;
-  private final EntityPropertiesFactory entityPropsFactory;
+  private final Map<String, EntityPropertiesFactory> entityPropsFactoryMap;
 
   /**
    * @param apiContainer       handles interaction with Wavefront servers as well as queueing.
    * @param proxyId            proxy ID.
    * @param taskQueueFactory   factory for backing queues.
-   * @param entityPropsFactory factory for entity-specific wrappers for mutable proxy settings.
+   * @param entityPropsFactoryMap map of factory for entity-specific wrappers for multiple
+   *                              multicasting mutable proxy settings.
    */
   public QueueingFactoryImpl(APIContainer apiContainer,
                              UUID proxyId,
                              final TaskQueueFactory taskQueueFactory,
-                             final EntityPropertiesFactory entityPropsFactory) {
+                             final Map<String, EntityPropertiesFactory> entityPropsFactoryMap) {
     this.apiContainer = apiContainer;
     this.proxyId = proxyId;
     this.taskQueueFactory = taskQueueFactory;
-    this.entityPropsFactory = entityPropsFactory;
+    this.entityPropsFactoryMap = entityPropsFactoryMap;
   }
 
   /**
@@ -71,8 +74,8 @@ public class QueueingFactoryImpl implements QueueingFactory {
     return (QueueProcessor<T>) queueProcessors.computeIfAbsent(handlerKey, x -> new TreeMap<>()).
         computeIfAbsent(threadNum, x -> new QueueProcessor<>(handlerKey, taskQueue,
             getTaskInjector(handlerKey, taskQueue), executorService,
-            entityPropsFactory.get(handlerKey.getEntityType()),
-            entityPropsFactory.getGlobalProperties()));
+            entityPropsFactoryMap.get(handlerKey.getTenantName()).get(handlerKey.getEntityType()),
+            entityPropsFactoryMap.get(handlerKey.getTenantName()).getGlobalProperties()));
   }
 
   @SuppressWarnings("unchecked")
@@ -87,7 +90,7 @@ public class QueueingFactoryImpl implements QueueingFactory {
         collect(Collectors.toList());
     return (QueueController<T>) queueControllers.computeIfAbsent(handlerKey, x ->
       new QueueController<>(handlerKey, queueProcessors,
-          backlogSize -> entityPropsFactory.get(handlerKey.getEntityType()).
+          backlogSize -> entityPropsFactoryMap.get(handlerKey.getTenantName()).get(handlerKey.getEntityType()).
               reportBacklogSize(handlerKey.getHandle(), backlogSize)));
   }
 
@@ -95,6 +98,7 @@ public class QueueingFactoryImpl implements QueueingFactory {
   private <T extends DataSubmissionTask<T>> TaskInjector<T> getTaskInjector(HandlerKey handlerKey,
                                                                             TaskQueue<T> queue) {
     ReportableEntityType entityType = handlerKey.getEntityType();
+    String tenantName = handlerKey.getTenantName();
     switch (entityType) {
       case POINT:
       case DELTA_COUNTER:
@@ -102,23 +106,38 @@ public class QueueingFactoryImpl implements QueueingFactory {
       case TRACE:
       case TRACE_SPAN_LOGS:
         return task -> ((LineDelimitedDataSubmissionTask) task).injectMembers(
-            apiContainer.getProxyV2API(), proxyId, entityPropsFactory.get(entityType),
+            apiContainer.getProxyV2APIForTenant(tenantName), proxyId,
+            entityPropsFactoryMap.get(tenantName).get(entityType),
             (TaskQueue<LineDelimitedDataSubmissionTask>) queue);
       case SOURCE_TAG:
         return task -> ((SourceTagSubmissionTask) task).injectMembers(
-            apiContainer.getSourceTagAPI(), entityPropsFactory.get(entityType),
+            apiContainer.getSourceTagAPIForTenant(tenantName),
+            entityPropsFactoryMap.get(tenantName).get(entityType),
             (TaskQueue<SourceTagSubmissionTask>) queue);
       case EVENT:
         return task -> ((EventDataSubmissionTask) task).injectMembers(
-            apiContainer.getEventAPI(), proxyId, entityPropsFactory.get(entityType),
+            apiContainer.getEventAPIForTenant(tenantName), proxyId,
+            entityPropsFactoryMap.get(tenantName).get(entityType),
             (TaskQueue<EventDataSubmissionTask>) queue);
       default:
         throw new IllegalArgumentException("Unexpected entity type: " + entityType);
     }
   }
 
+  /**
+   * The parameter handlerKey is port specific rather than tenant specific, need to convert to
+   * port + tenant specific format so that correct task can be shut down properly.
+   *
+   * @param handlerKey port specific handlerKey
+   */
   @VisibleForTesting
   public void flushNow(@Nonnull HandlerKey handlerKey) {
-    queueProcessors.get(handlerKey).values().forEach(QueueProcessor::run);
+    ReportableEntityType entityType = handlerKey.getEntityType();
+    String handle = handlerKey.getHandle();
+    HandlerKey tenantHandlerKey;
+    for (String tenantName : apiContainer.getTenantNameList()) {
+      tenantHandlerKey = HandlerKey.of(entityType, handle, tenantName);
+      queueProcessors.get(tenantHandlerKey).values().forEach(QueueProcessor::run);
+    }
   }
 }

--- a/proxy/src/test/java/com/wavefront/agent/api/APIContainerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/api/APIContainerTest.java
@@ -1,0 +1,66 @@
+package com.wavefront.agent.api;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.wavefront.agent.ProxyConfig;
+import com.wavefront.api.ProxyV2API;
+
+import org.checkerframework.checker.units.qual.A;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Xiaochen Wang (xiaochenw@vmware.com).
+ */
+public class APIContainerTest {
+    private final int NUM_TENANTS = 5;
+  private ProxyConfig proxyConfig;
+
+  @Before
+  public void setup() {
+    this.proxyConfig = new ProxyConfig();
+    this.proxyConfig.getMulticastingTenantList().put("central",
+        ImmutableMap.of("token", "fake-token", "server", "fake-url"));
+    for (int i = 0; i < NUM_TENANTS; i++) {
+      this.proxyConfig.getMulticastingTenantList().put("tenant-" + i,
+          ImmutableMap.of("token", "fake-token" + i, "server", "fake-url" + i));
+    }
+  }
+
+  @Test
+  public void testAPIContainerInitiationWithDiscardData() {
+    APIContainer apiContainer = new APIContainer(this.proxyConfig, true);
+    assertEquals(apiContainer.getTenantNameList().size(), 1);
+    assertTrue(apiContainer.getProxyV2APIForTenant("central") instanceof NoopProxyV2API);
+    assertTrue(apiContainer.getSourceTagAPIForTenant("central") instanceof NoopSourceTagAPI);
+    assertTrue(apiContainer.getEventAPIForTenant("central") instanceof NoopEventAPI);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testUpdateServerEndpointURLWithNullProxyConfig() {
+    APIContainer apiContainer = new APIContainer(null, null, null);
+    apiContainer.updateServerEndpointURL("central", "fake-url");
+  }
+
+  @Test
+  public void testUpdateServerEndpointURLWithValidProxyConfig() {
+    APIContainer apiContainer = new APIContainer(this.proxyConfig, false);
+    assertEquals(apiContainer.getTenantNameList().size(), NUM_TENANTS + 1);
+    apiContainer.updateServerEndpointURL("central", "another-fake-url");
+    assertEquals(apiContainer.getTenantNameList().size(), NUM_TENANTS + 1);
+    assertNotNull(apiContainer.getProxyV2APIForTenant("central"));
+
+    apiContainer = new APIContainer(this.proxyConfig, true);
+    assertEquals(apiContainer.getTenantNameList().size(), 1);
+    apiContainer.updateServerEndpointURL("central", "another-fake-url");
+    assertEquals(apiContainer.getTenantNameList().size(), 1);
+    assertNotNull(apiContainer.getProxyV2APIForTenant("central"));
+    assertTrue(apiContainer.getProxyV2APIForTenant("central") instanceof NoopProxyV2API);
+    assertTrue(apiContainer.getSourceTagAPIForTenant("central") instanceof NoopSourceTagAPI);
+    assertTrue(apiContainer.getEventAPIForTenant("central") instanceof NoopEventAPI);
+  }
+}

--- a/proxy/src/test/java/com/wavefront/agent/handlers/ReportSourceTagHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/handlers/ReportSourceTagHandlerTest.java
@@ -1,6 +1,7 @@
 package com.wavefront.agent.handlers;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import com.wavefront.agent.api.APIContainer;
 import com.wavefront.agent.data.DefaultEntityPropertiesFactoryForTesting;
@@ -20,13 +21,16 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 import javax.ws.rs.core.Response;
 
+import edu.emory.mathcs.backport.java.util.Collections;
 import wavefront.report.ReportSourceTag;
 import wavefront.report.SourceOperationType;
 import wavefront.report.SourceTagAction;
@@ -58,7 +62,8 @@ public class ReportSourceTagHandlerTest {
     };
     newAgentId = UUID.randomUUID();
     senderTaskFactory = new SenderTaskFactoryImpl(new APIContainer(null, mockAgentAPI, null),
-        newAgentId, taskQueueFactory, null, new DefaultEntityPropertiesFactoryForTesting());
+        newAgentId, taskQueueFactory, null,
+        Collections.singletonMap(APIContainer.CENTRAL_TENANT_NAME, new DefaultEntityPropertiesFactoryForTesting()));
     handlerKey = HandlerKey.of(ReportableEntityType.SOURCE_TAG, "4878");
     sourceTagHandler = new ReportSourceTagHandlerImpl(handlerKey, 10,
             senderTaskFactory.createSenderTasks(handlerKey), null, blockedLogger);
@@ -143,8 +148,10 @@ public class ReportSourceTagHandlerTest {
     SourceTagSenderTask task2 = EasyMock.createMock(SourceTagSenderTask.class);
     tasks.add(task1);
     tasks.add(task2);
+    Map<String, Collection<SenderTask<SourceTag>>> taskMap =
+        ImmutableMap.of(APIContainer.CENTRAL_TENANT_NAME, tasks);
     ReportSourceTagHandlerImpl sourceTagHandler = new ReportSourceTagHandlerImpl(
-        HandlerKey.of(ReportableEntityType.SOURCE_TAG, "4878"), 10, tasks, null, blockedLogger);
+        HandlerKey.of(ReportableEntityType.SOURCE_TAG, "4878"), 10, taskMap, null, blockedLogger);
     task1.add(new SourceTag(sourceTag1));
     EasyMock.expectLastCall();
     task1.add(new SourceTag(sourceTag2));


### PR DESCRIPTION
This is feature request from Dell Dimension ([Jira](https://wavefront.atlassian.net/browse/MONIT-25479))
Changes summary:
- Refactored `ProxyConfig` and `APIContainer` so that we can config multicasting tenants.
- Refactored `HandlerKey` to include tenant name.
- Main refactoring at `SenderTaskFacotryImpl` where it initiates tenant specific `SenderTask` and `QueueController`.
- Refactored the `reportInternal()` function of various data type's `ReportableEntityHandler` where we check the tag key `multicastingTenantName` to decide if corresponding data should be multicasted.
- example config file:
```
retryThreads=0
server=https://surf.wavefront.com/api
hostname=xiaochen_laptop
token=<surf_token>
pushListenerPorts=2878
deltaCountersAggregationListenerPorts = 12878

buffer=/tmp/wf-proxy-buffer

multicastingTenants=2

multicastingTenantName_1=longboard
multicastingServer_1=https://longboard.wavefront.com/api
multicastingToken_1=<longboard_token>

multicastingTenantName_2=tracing
multicastingServer_2=https://tracing.wavefront.com/api
multicastingToken_2=<tracing_token>

pushFlushMaxPoints=40000
pushFlushInterval=1000
pushBlockedSamples=5

pushLogLevel=SUMMARY
pushValidationLevel=NUMERIC_ONLY

idFile=wavefront_test_id
```