### PR TITLE
WFESO-4015: Update OSSRH host to mitigate timeouts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>


### PR DESCRIPTION
Build issues ticket for sonatype - https://issues.sonatype.org/browse/OSSRH-76156
After discussion on the above issue, created host migration request (as per comments)

Host migration request - https://issues.sonatype.org/browse/OSSRH-76161


Due to log4j day 0 vuln issues, sonatype hosts are overwhelmed.
Migrated the com.wavefront project to a new host with less load to mitigate build issues.