### PR TITLE
Revert "WFESO-4015: update ossrh host to mitigate timeouts (#681)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
-              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>


### PR DESCRIPTION
This reverts commit 4aa2911c7b8e8091f4aae5b19342ccc3b5bcaa6b.

Since the new ossrh host has some issues with auth, we will retry using the old host