### PR TITLE
Bump log4j-api from 2.16.0 to 2.17.0 (#690)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
     <java.version>1.8</java.version>
     <javadoc.sdk.version>8</javadoc.sdk.version>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.0</log4j.version>
     <jackson.version>2.12.3</jackson.version>
     <jackson-databind.version>2.12.3</jackson-databind.version>
     <netty.version>4.1.71.Final</netty.version>


### PR DESCRIPTION
Bumps log4j-api from 2.16.0 to 2.17.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>