### PR TITLE
makefile changes to have consistent names of artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,20 @@ USER ?= $(LOGNAME)
 REPO ?= proxy-dev
 PACKAGECLOUD_USER ?= wavefront
 PACKAGECLOUD_REPO ?= proxy-next
+IS_GA ?= false
 
-DOCKER_TAG = $(USER)/$(REPO):${FULLVERSION}
+ifeq ($(IS_GA), true)
+  DOCKER_TAG = $(USER)/$(REPO):${VERSION}
+else
+  DOCKER_TAG = $(USER)/$(REPO):${FULLVERSION}
+endif
+
 
 out = $(shell pwd)/out
 $(shell mkdir -p $(out))
 
 .info:
-	@echo "\n----------\nBuilding Proxy ${FULLVERSION}\nDocker tag: ${DOCKER_TAG}\n----------\n"
+	@echo "\n----------\nBuilding Proxy ${VERSION}\nDocker tag: ${DOCKER_TAG}\n----------\n"
 
 jenkins: .info build-jar build-linux push-linux docker-multi-arch clean
 
@@ -44,7 +50,7 @@ docker-multi-arch: .info .cp-docker
 # Build rep & deb packages
 #####
 build-linux: .info .prepare-builder .cp-linux
-	docker run -v $(shell pwd)/:/proxy proxy-linux-builder /proxy/pkg/build.sh ${VERSION} ${REVISION}
+	docker run -v $(shell pwd)/:/proxy proxy-linux-builder /proxy/pkg/build.sh ${VERSION} 1
 	
 #####
 # Push rep & deb packages


### PR DESCRIPTION
Makefile variables create artifacts with new filenames. 
Shuffle the variables around to have consistency in files names and docker tags we upload for GA and non-GA builds.

For example:
For proxy-snapshot (non-GA)
- docker_tag: `10.14_20220119-1538` <- comes with the timestamp at the end. [Reference](https://hub.docker.com/layers/wavefronthq/proxy-snapshot/10.14_20220119-1538/images/sha256-7caffe10964e48f16ca031f4416309d45f6b22b2f1195f4d0ba1d5162f09e978?context=explore)
- DEB/RPM: `wavefront-proxy_10.14-1_amd64.deb` <- comes with iteration "1" appended after release version. [Reference](https://packagecloud.io/wavefront/proxy-next/packages/ubuntu/bionic/wavefront-proxy_10.14-1_amd64.deb)

For proxy (GA)
- docker_tag: `10.14` <- Do not append timestamp. [Reference](https://hub.docker.com/layers/wavefronthq/proxy/10.14/images/sha256-4f02ad81a9c7946593e9cec049a021e32f96aaba3214ec7e5dfd708000966605?context=explore)
- DEB/RPM: `wavefront-proxy_10.14-1_amd64.deb` <- comes with iteration "1" appended after release version, same as non-GA. [Reference](https://packagecloud.io/wavefront/proxy/packages/ubuntu/eoan/wavefront-proxy_10.14-1_amd64.deb)