### PR TITLE
[MONIT-26336] Add span future fill limit of 24 hours

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/handlers/SpanHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/handlers/SpanHandlerImpl.java
@@ -87,6 +87,11 @@ public class SpanHandlerImpl extends AbstractReportableEntityHandler<Span, Strin
       this.reject(span, "span is older than acceptable delay of " + maxSpanDelay + " minutes");
       return;
     }
+    // Spans cannot exceed 24 hours future fill
+    if (span.getStartMillis() > Clock.now() + TimeUnit.HOURS.toMillis(24)) {
+      this.reject(span, "Span outside of reasonable timeframe");
+      return;
+    }
     //PUB-323 Allow "*" in span name by converting "*" to "-"
     if (span.getName().contains("*")) {
       span.setName(span.getName().replace('*', '-'));


### PR DESCRIPTION
To test span is rejected when start time exceeds 24 hours, run:
`echo "test-span-24-hours-ahead source=test-source traceId=7b3bf470-9456-11e8-9eb6-529269fb1513 spanId=0313bafe-9457-11e8-9eb6-529269fb1459 parent=2f64e538-9457-11e8-9eb6-529269fb1459 application=Wavefront service=istio cluster=none shard=none http.method=GET <time-in-milliseconds> <duration-in-milliseconds>" | curl -H "Authorization: Bearer <token>" --data @- https://<cluster>.wavefront.com:30000/report`