### PR TITLE
[MONIT-28676] Fix pointline for extractTag and extractTagIfNotExists

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointExtractTagTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointExtractTagTransformer.java
@@ -74,25 +74,46 @@ public class ReportPointExtractTagTransformer implements Function<ReportPoint, R
   protected void internalApply(@Nonnull ReportPoint reportPoint) {
     switch (source) {
       case "metricName":
-        if (extractTag(reportPoint, reportPoint.getMetric()) && patternReplaceSource != null) {
-          reportPoint.setMetric(compiledSearchPattern.matcher(reportPoint.getMetric()).
-              replaceAll(expandPlaceholders(patternReplaceSource, reportPoint)));
-        }
+        applyMetricName(reportPoint);
         break;
       case "sourceName":
-        if (extractTag(reportPoint, reportPoint.getHost()) && patternReplaceSource != null) {
-          reportPoint.setHost(compiledSearchPattern.matcher(reportPoint.getHost()).
-              replaceAll(expandPlaceholders(patternReplaceSource, reportPoint)));
+        applySourceName(reportPoint);
+        break;
+      case "pointLine":
+        applyMetricName(reportPoint);
+        applySourceName(reportPoint);
+        if (reportPoint.getAnnotations() != null ) {
+          for (String tagKey : reportPoint.getAnnotations().keySet()) {
+            applyPointTagKey(reportPoint, tagKey);
+          }
         }
         break;
       default:
-        if (reportPoint.getAnnotations() != null && reportPoint.getAnnotations().get(source) != null) {
-          if (extractTag(reportPoint, reportPoint.getAnnotations().get(source)) && patternReplaceSource != null) {
-            reportPoint.getAnnotations().put(source,
-                compiledSearchPattern.matcher(reportPoint.getAnnotations().get(source)).
-                    replaceAll(expandPlaceholders(patternReplaceSource, reportPoint)));
-          }
-        }
+        applyPointTagKey(reportPoint, source);
+    }
+  }
+
+  public void applyMetricName(ReportPoint reportPoint) {
+    if (extractTag(reportPoint, reportPoint.getMetric()) && patternReplaceSource != null) {
+      reportPoint.setMetric(compiledSearchPattern.matcher(reportPoint.getMetric()).
+          replaceAll(expandPlaceholders(patternReplaceSource, reportPoint)));
+    }
+  }
+
+  public void applySourceName(ReportPoint reportPoint) {
+    if (extractTag(reportPoint, reportPoint.getHost()) && patternReplaceSource != null) {
+      reportPoint.setHost(compiledSearchPattern.matcher(reportPoint.getHost()).
+          replaceAll(expandPlaceholders(patternReplaceSource, reportPoint)));
+    }
+  }
+
+  public void applyPointTagKey(ReportPoint reportPoint, String tagKey) {
+    if (reportPoint.getAnnotations() != null && reportPoint.getAnnotations().get(tagKey) != null) {
+      if (extractTag(reportPoint, reportPoint.getAnnotations().get(tagKey)) && patternReplaceSource != null) {
+        reportPoint.getAnnotations().put(tagKey,
+            compiledSearchPattern.matcher(reportPoint.getAnnotations().get(tagKey)).
+                replaceAll(expandPlaceholders(patternReplaceSource, reportPoint)));
+      }
     }
   }
 

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
@@ -614,6 +614,98 @@ public class PreprocessorRulesTest {
     }
   }
 
+  /**
+   * For extractTag create the new point tag.
+   */
+  @Test
+  public void testExtractTagPointLineRule() {
+    String preprocessorTag = " \"newExtractTag\"=\"newExtractTagValue\"";
+
+    // No match in pointline - shouldn't change anything
+    String noMatchPointString =
+        "\"No Match Metric\" 1.0 1459527231 source=\"hostname\" \"foo\"=\"bar\"";
+    ReportPoint noMatchPoint = parsePointLine(noMatchPointString);
+    new ReportPointExtractTagTransformer(
+        "newExtractTag", "pointLine", ".*extractTag.*",
+        "newExtractTagValue", null, null,null, metrics)
+        .apply(noMatchPoint);
+    assertEquals(noMatchPointString, referencePointToStringImpl(noMatchPoint));
+
+    // Metric name matches in pointLine - newExtractTag=newExtractTagValue should be added
+    String metricNameMatchString =
+        "\"extractTagMetric\" 1.0 1459527231 source=\"testHost\" \"foo\"=\"bar\"";
+    ReportPoint metricNameMatchPoint =
+        parsePointLine(metricNameMatchString);
+    String MetricNameUpdatedTag = metricNameMatchString + preprocessorTag;
+    new ReportPointExtractTagTransformer(
+        "newExtractTag", "pointLine", ".*extractTag.*",
+        "newExtractTagValue", null, null,null, metrics)
+        .apply(metricNameMatchPoint);
+    assertEquals(MetricNameUpdatedTag, referencePointToStringImpl(metricNameMatchPoint));
+
+    // Source name matches in pointLine - newExtractTag=newExtractTagValue should be added
+    String sourceNameMatchString =
+        "\"testTagMetric\" 1.0 1459527231 source=\"extractTagHost\" \"foo\"=\"bar\"";
+    ReportPoint sourceNameMatchPoint = parsePointLine(sourceNameMatchString);
+    String SourceNameUpdatedTag = sourceNameMatchString + preprocessorTag;
+    new ReportPointExtractTagTransformer(
+        "newExtractTag", "pointLine", ".*extractTag.*",
+        "newExtractTagValue", null, null,null, metrics)
+        .apply(sourceNameMatchPoint);
+    assertEquals(SourceNameUpdatedTag, referencePointToStringImpl(sourceNameMatchPoint));
+
+    // Point tag value matches in pointLine - newExtractTag=newExtractTagValue should be added
+    String tagNameMatchString =
+        "\"testTagMetric\" 1.0 1459527231 source=\"testHost\" \"aTag\"=\"extractTagTest\"";
+    ReportPoint pointTagMatchPoint = parsePointLine(tagNameMatchString);
+    String pointTagUpdated = tagNameMatchString + preprocessorTag;
+    new ReportPointExtractTagTransformer(
+        "newExtractTag", "pointLine", ".*extractTag.*",
+        "newExtractTagValue", null, null,null, metrics)
+        .apply(pointTagMatchPoint);
+    assertEquals(pointTagUpdated, referencePointToStringImpl(pointTagMatchPoint));
+
+    // Point tag already exists, new value is set
+    String originalPointStringWithTag = "\"extractTagMetric\" 1.0 1459527231 source=\"testHost\"";
+    ReportPoint existingTagMatchPoint = parsePointLine(originalPointStringWithTag +
+        "\"newExtractTag\"=\"originalValue\"");
+    new ReportPointExtractTagTransformer(
+        "newExtractTag", "pointLine", ".*extractTag.*",
+        "newExtractTagValue", null, null,null, metrics)
+        .apply(existingTagMatchPoint);
+    assertEquals(originalPointStringWithTag + preprocessorTag,
+        referencePointToStringImpl(existingTagMatchPoint));
+  }
+
+  /**
+   * For extractTagIfNotExists create the new point tag but do not replace the existing value with
+   * the new value if the tag already exists.
+   */
+  @Test
+  public void testExtractTagIfNotExistsPointLineRule() {
+    // Point tag value matches in pointLine - newExtractTag=newExtractTagValue should be added
+    String addedTag = " \"newExtractTag\"=\"newExtractTagValue\"";
+    String originalPointStringWithTag = "\"extractTagMetric\" 1.0 1459527231 source=\"testHost\" "
+        + "\"aKey\"=\"aValue\"";
+    ReportPoint existingTagMatchPoint = parsePointLine(originalPointStringWithTag);
+    new ReportPointExtractTagTransformer(
+        "newExtractTag", "pointLine", ".*extractTag.*",
+        "newExtractTagValue", null, null,null, metrics)
+        .apply(existingTagMatchPoint);
+    assertEquals(originalPointStringWithTag + addedTag,
+        referencePointToStringImpl(existingTagMatchPoint));
+
+    // Point tag already exists, keep existing value.
+    String originalTagExistsString = "\"extractTagMetric\" 1.0 1459527231 source=\"testHost\" " +
+            "\"newExtractTag\"=\"originalValue\"";
+    ReportPoint tagExistsMatchPoint = parsePointLine(originalTagExistsString);
+    new ReportPointExtractTagIfNotExistsTransformer(
+        "newExtractTag", "pointLine", ".*extractTag.*",
+        "newExtractTagValue", null, null,null, metrics)
+        .apply(tagExistsMatchPoint);
+    assertEquals(originalTagExistsString, referencePointToStringImpl(tagExistsMatchPoint));
+  }
+
   private boolean applyAllFilters(String pointLine, String strPort) {
     return applyAllFilters(config,pointLine,strPort);
   }

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
@@ -688,7 +688,7 @@ public class PreprocessorRulesTest {
     String originalPointStringWithTag = "\"extractTagMetric\" 1.0 1459527231 source=\"testHost\" "
         + "\"aKey\"=\"aValue\"";
     ReportPoint existingTagMatchPoint = parsePointLine(originalPointStringWithTag);
-    new ReportPointExtractTagTransformer(
+    new ReportPointExtractTagIfNotExistsTransformer(
         "newExtractTag", "pointLine", ".*extractTag.*",
         "newExtractTagValue", null, null,null, metrics)
         .apply(existingTagMatchPoint);


### PR DESCRIPTION
Fixes source as pointLine for addTag and addTagIfNotExists Preprocessor Rules. https://docs.wavefront.com/proxies_preprocessor_rules.html#extracttag-and-extracttagifnotexists

Testing:

1. Add the following to proxy/preprocessor_rules.yaml:
```
  # add tag hasTenantId
  - rule : extract-tenantfinal
    action : extractTagIfNotExists
    source : pointLine
    tag : newAddedTag
    search : ".*device.*"
    replace : "newTag"

```
2. Confirm that new tag newAddedTag is added to metric with value newTag when metric name, source name or point tag value matches search regex.
3. When `action: extractTag` and tag newAddedTag already exists, confirm new value is set.
4. When `action: extractTagIfNotExists` and tag newAddedTag already exists, confirm original value is kept.