### PR TITLE
move back the current version in pom.xml to a RC release on dev branch

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.wavefront</groupId>
   <artifactId>proxy</artifactId>
-  <version>11.3-SNAPSHOT</version>
+  <version>12.0-RC0-SNAPSHOT</version>
 
   <name>Wavefront Proxy</name>
   <description>Service for batching and relaying metric traffic to Wavefront</description>


### PR DESCRIPTION
We merged `release-11.x` branch into `master`.
This updated the RC release version in the pom.xml to the one we're using in `release-11.x`.
Commit below - 
https://github.com/wavefrontHQ/wavefront-proxy/commit/32842a39c1868efd36a54bd0c08c47a024cb7969

Revert back to RC in the release version to create appropriate RC releases.