### PR TITLE
WFESO-4697: fix mac tarball workflow

### DIFF
--- a/.github/workflows/mac_tarball_notarization.yml
+++ b/.github/workflows/mac_tarball_notarization.yml
@@ -41,6 +41,5 @@ jobs:
     - name: "${{ github.event.inputs.proxy_version }}-${{ github.event.inputs.release_type }}-notarize"
       run: |
         set -x
-        echo "chmod +x ./macos_proxy_notarization/proxy_notarization.sh; ./macos_proxy_notarization/proxy_notarization.sh 'wfproxy-${{ github.event.inputs.proxy_version }}.tar.gz'"
+        chmod +x ./macos_proxy_notarization/proxy_notarization.sh; ./macos_proxy_notarization/proxy_notarization.sh 'wfproxy-${{ github.event.inputs.proxy_version }}.tar.gz'
         set +x
-        sleep 60


### PR DESCRIPTION
Remove `echo` a `sleep` introduced during testing in github workflow for mac tarball notarization