### PR TITLE
[MONIT-29838] ExtractTag and extractTagIfNotExists Preprocessor Update

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointExtractTagTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointExtractTagTransformer.java
@@ -4,6 +4,8 @@ import static com.wavefront.predicates.Util.expandPlaceholders;
 
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -80,11 +82,7 @@ public class ReportPointExtractTagTransformer implements Function<ReportPoint, R
       case "pointLine":
         applyMetricName(reportPoint);
         applySourceName(reportPoint);
-        if (reportPoint.getAnnotations() != null) {
-          for (String tagKey : reportPoint.getAnnotations().keySet()) {
-            applyPointTagKey(reportPoint, tagKey);
-          }
-        }
+        applyPointLineTag(reportPoint);
         break;
       default:
         applyPointTagKey(reportPoint, source);
@@ -106,6 +104,23 @@ public class ReportPointExtractTagTransformer implements Function<ReportPoint, R
           compiledSearchPattern
               .matcher(reportPoint.getHost())
               .replaceAll(expandPlaceholders(patternReplaceSource, reportPoint)));
+    }
+  }
+
+  public void applyPointLineTag(ReportPoint reportPoint) {
+    if (reportPoint.getAnnotations() != null) {
+      for (Map.Entry<String, String> pointTag : reportPoint.getAnnotations().entrySet()) {
+        if ((extractTag(reportPoint,pointTag.getKey()) ||
+            extractTag(reportPoint, pointTag.getValue())) && patternReplaceSource != null) {
+          reportPoint
+              .getAnnotations()
+              .put(
+                  pointTag.getKey(),
+                  compiledSearchPattern
+                      .matcher(reportPoint.getAnnotations().get(pointTag.getKey()))
+                      .replaceAll(expandPlaceholders(patternReplaceSource, reportPoint)));
+        }
+      }
     }
   }
 

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointExtractTagTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointExtractTagTransformer.java
@@ -4,7 +4,6 @@ import static com.wavefront.predicates.Util.expandPlaceholders;
 
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -110,8 +109,9 @@ public class ReportPointExtractTagTransformer implements Function<ReportPoint, R
   public void applyPointLineTag(ReportPoint reportPoint) {
     if (reportPoint.getAnnotations() != null) {
       for (Map.Entry<String, String> pointTag : reportPoint.getAnnotations().entrySet()) {
-        if ((extractTag(reportPoint,pointTag.getKey()) ||
-            extractTag(reportPoint, pointTag.getValue())) && patternReplaceSource != null) {
+        if ((extractTag(reportPoint, pointTag.getKey())
+                || extractTag(reportPoint, pointTag.getValue()))
+            && patternReplaceSource != null) {
           reportPoint
               .getAnnotations()
               .put(

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
@@ -793,6 +793,23 @@ public class PreprocessorRulesTest {
         .apply(sourceNameMatchPoint);
     assertEquals(SourceNameUpdatedTag, referencePointToStringImpl(sourceNameMatchPoint));
 
+    // Point tag key matches in pointLine - newExtractTag=newExtractTagValue should be added
+    String tagKeyMatchString =
+        "\"testTagMetric\" 1.0 1459527231 source=\"testHost\" \"extractTagKey\"=\"value\"";
+    ReportPoint pointTagKeyMatchPoint = parsePointLine(tagKeyMatchString);
+    String pointTagKeyUpdated = tagKeyMatchString + preprocessorTag;
+    new ReportPointExtractTagTransformer(
+        "newExtractTag",
+        "pointLine",
+        ".*extractTag.*",
+        "newExtractTagValue",
+        null,
+        null,
+        null,
+        metrics)
+        .apply(pointTagKeyMatchPoint);
+    assertEquals(pointTagKeyUpdated, referencePointToStringImpl(pointTagKeyMatchPoint));
+
     // Point tag value matches in pointLine - newExtractTag=newExtractTagValue should be added
     String tagNameMatchString =
         "\"testTagMetric\" 1.0 1459527231 source=\"testHost\" \"aTag\"=\"extractTagTest\"";

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
@@ -799,14 +799,14 @@ public class PreprocessorRulesTest {
     ReportPoint pointTagKeyMatchPoint = parsePointLine(tagKeyMatchString);
     String pointTagKeyUpdated = tagKeyMatchString + preprocessorTag;
     new ReportPointExtractTagTransformer(
-        "newExtractTag",
-        "pointLine",
-        ".*extractTag.*",
-        "newExtractTagValue",
-        null,
-        null,
-        null,
-        metrics)
+            "newExtractTag",
+            "pointLine",
+            ".*extractTag.*",
+            "newExtractTagValue",
+            null,
+            null,
+            null,
+            metrics)
         .apply(pointTagKeyMatchPoint);
     assertEquals(pointTagKeyUpdated, referencePointToStringImpl(pointTagKeyMatchPoint));
 


### PR DESCRIPTION
This commit includes point tag key in search, as source=pointLine rule applies to the whole point line.
Testing:

Add the following to proxy/preprocessor_rules.yaml:
```
  # add tag hasTenantId
  - rule : extract-tenantfinal
    action : extractTagIfNotExists
    source : pointLine
    tag : newAddedTag
    search : ".*device.*"
    replace : "newTag"
```

Confirm that new tag newAddedTag is added to metric with value newTag when **point tag key** matches search regex.
When action: extractTag and tag newAddedTag already exists, confirm new value is set.
When action: extractTagIfNotExists and tag newAddedTag already exists, confirm original value is kept.