### PR TITLE
[MONIT-28882] Use a non named user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ EXPOSE 3878
 EXPOSE 2878
 EXPOSE 4242
 
-USER wavefront:wavefront
+USER 1000:2000
 
 ADD wavefront-proxy.jar /opt/wavefront/wavefront-proxy/wavefront-proxy.jar
 ADD run.sh /opt/wavefront/wavefront-proxy/run.sh


### PR DESCRIPTION
Use a non named user to enable proxy deployment on security enabled k8s clusters like TKGS or TMC with TKGm