### PR TITLE
Accept OpenTelemetry metrics with int/long values

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpMetricsUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpMetricsUtils.java
@@ -326,10 +326,15 @@ public class OtlpMetricsUtils {
   @NotNull
   private static ReportPoint transformNumberDataPoint(
       String name, NumberDataPoint point, List<KeyValue> resourceAttrs) {
-    return pointWithAnnotations(
-            name, point.getAttributesList(), resourceAttrs, point.getTimeUnixNano())
-        .setValue(point.getAsDouble())
-        .build();
+    ReportPoint.Builder rp =
+        pointWithAnnotations(
+            name, point.getAttributesList(), resourceAttrs, point.getTimeUnixNano());
+
+    if (point.hasAsInt()) {
+      return rp.setValue(point.getAsInt()).build();
+    } else {
+      return rp.setValue(point.getAsDouble()).build();
+    }
   }
 
   @NotNull

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpMetricsUtilsTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpMetricsUtilsTest.java
@@ -231,12 +231,12 @@ public class OtlpMetricsUtilsTest {
   }
 
   @Test
-  public void acceptsSumWithMultipleDataPoints() {
+  public void acceptsSumWithIntAndDoubleDataPoints() {
     List<NumberDataPoint> points =
         ImmutableList.of(
             NumberDataPoint.newBuilder()
                 .setTimeUnixNano(TimeUnit.SECONDS.toNanos(1))
-                .setAsDouble(1.0)
+                .setAsInt(1)
                 .build(),
             NumberDataPoint.newBuilder()
                 .setTimeUnixNano(TimeUnit.SECONDS.toNanos(2))
@@ -248,7 +248,7 @@ public class OtlpMetricsUtilsTest {
         ImmutableList.of(
             OtlpTestHelpers.wfReportPointGenerator()
                 .setTimestamp(TimeUnit.SECONDS.toMillis(1))
-                .setValue(1.0)
+                .setValue(1)
                 .build(),
             OtlpTestHelpers.wfReportPointGenerator()
                 .setTimestamp(TimeUnit.SECONDS.toMillis(2))


### PR DESCRIPTION
Prior to this fix, we assumed data points in OpenTelemetry metrics always had double values. If a data point instead had an int/long value, the resulting WF metric would have a likely incorrect value of 0.0.