### PR TITLE
MONIT-30269: changes to ingested "error_name" instead of "exception" for summary

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -402,7 +402,7 @@
     <dependency>
       <groupId>com.wavefront</groupId>
       <artifactId>java-lib</artifactId>
-      <version>2022-08.1</version>
+      <version>2022-08.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/proxy/src/main/java/com/wavefront/agent/ProxyConfig.java
+++ b/proxy/src/main/java/com/wavefront/agent/ProxyConfig.java
@@ -1310,6 +1310,22 @@ public class ProxyConfig extends Configuration {
   String customServiceTags = "";
 
   @Parameter(
+      names = {"--customExceptionTags"},
+      description =
+          "Comma separated list of log tag "
+              + "keys that should be treated as the exception in Wavefront in the absence of a "
+              + "tag named `exception`. Default: exception, error_name")
+  String customExceptionTags = "";
+
+  @Parameter(
+      names = {"--customLevelTags"},
+      description =
+          "Comma separated list of log tag "
+              + "keys that should be treated as the log level in Wavefront in the absence of a "
+              + "tag named `level`. Default: level, log_level")
+  String customLevelTags = "";
+
+  @Parameter(
       names = {"--multicastingTenants"},
       description = "The number of tenants to data " + "points" + " multicasting. Default: 0")
   protected int multicastingTenants = 0;
@@ -1989,6 +2005,39 @@ public class ProxyConfig extends Configuration {
     return new ArrayList<>(tagSet);
   }
 
+  public List<String> getCustomExceptionTags() {
+    Set<String> tagSet = new LinkedHashSet<>();
+    Splitter.on(",")
+        .trimResults()
+        .omitEmptyStrings()
+        .split(customExceptionTags)
+        .forEach(
+            x -> {
+              if (!tagSet.add(x)) {
+                logger.warning(
+                    "Duplicate tag " + x + " specified in customExceptionTags config setting");
+              }
+            });
+    return new ArrayList<>(tagSet);
+  }
+
+  public List<String> getCustomLevelTags() {
+    // create List of level tags from the configuration string
+    Set<String> tagSet = new LinkedHashSet<>();
+    Splitter.on(",")
+        .trimResults()
+        .omitEmptyStrings()
+        .split(customLevelTags)
+        .forEach(
+            x -> {
+              if (!tagSet.add(x)) {
+                logger.warning(
+                    "Duplicate tag " + x + " specified in customLevelTags config setting");
+              }
+            });
+    return new ArrayList<>(tagSet);
+  }
+
   public Map<String, String> getAgentMetricsPointTags() {
     //noinspection UnstableApiUsage
     return agentMetricsPointTags == null
@@ -2446,6 +2495,8 @@ public class ProxyConfig extends Configuration {
       splitPushWhenRateLimited =
           config.getBoolean("splitPushWhenRateLimited", splitPushWhenRateLimited);
       customSourceTags = config.getString("customSourceTags", customSourceTags);
+      customLevelTags = config.getString("customLevelTags", customLevelTags);
+      customExceptionTags = config.getString("customExceptionTags", customExceptionTags);
       agentMetricsPointTags = config.getString("agentMetricsPointTags", agentMetricsPointTags);
       ephemeral = config.getBoolean("ephemeral", ephemeral);
       disableRdnsLookup = config.getBoolean("disableRdnsLookup", disableRdnsLookup);

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -196,7 +196,9 @@ public class PushAgent extends AbstractAgent {
                               proxyConfig.getCustomTimestampTags(),
                               proxyConfig.getCustomMessageTags(),
                               proxyConfig.getCustomApplicationTags(),
-                              proxyConfig.getCustomServiceTags()))
+                              proxyConfig.getCustomServiceTags(),
+                              proxyConfig.getCustomLevelTags(),
+                              proxyConfig.getCustomExceptionTags()))
                       .build());
   // default rate sampler which always samples.
   protected final RateSampler rateSampler = new RateSampler(1.0d);

--- a/proxy/src/test/java/com/wavefront/agent/HttpEndToEndTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/HttpEndToEndTest.java
@@ -743,11 +743,15 @@ public class HttpEndToEndTest {
         "[{\"source\": \"myHost\",\n \"timestamp\": \""
             + timestamp
             + "\", "
-            + "\"application\":\"myApp\",\"service\":\"myService\"}]";
+            + "\"application\":\"myApp\",\"service\":\"myService\","
+            + "\"log_level\":\"WARN\",\"error_name\":\"myException\""
+            + "}]";
     String expectedLog =
         "[{\"source\":\"myHost\",\"timestamp\":"
             + timestamp
-            + ",\"text\":\"\",\"application\":\"myApp\",\"service\":\"myService\"}]";
+            + ",\"text\":\"\",\"application\":\"myApp\",\"service\":\"myService\","
+            + "\"log_level\":\"WARN\",\"error_name\":\"myException\""
+            + "}]";
     AtomicBoolean gotLog = new AtomicBoolean(false);
     server.update(
         req -> {


### PR DESCRIPTION
- changes to ingested "error_name" instead of "exception" for summary
- User can provide custom exception and log level tags names for alert summary page.