### PR TITLE
proxy-pom.xml: skip format-code plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Please refer to the [project page](https://github.com/wavefrontHQ/wavefront-prox
 git clone https://github.com/wavefronthq/wavefront-proxy
 cd wavefront-proxy
 mvn -f proxy clean install -DskipTests
+
+If you want to skip code formatting during build use:
+mvn -f proxy clean install -DskipTests -DskipFormatCode
 ```
 
 ## Contributing

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -99,6 +99,12 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+            <skip>${skipFormatCode}</skip>
+            <googleJavaFormatOptions>
+                <aosp>true</aosp>
+            </googleJavaFormatOptions>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
On the released tags tarball 11.4 and 12.0, `mvn -f proxy clean install -DskipTest` fails to execute format-code on project proxy because it expects the source to be git repository. 

> [ERROR] Failed to execute goal com.cosium.code:git-code-format-maven-plugin:3.3:format-code (format-code) on project proxy: Execution format-code of goal com.cosium.code:git-code-format-maven-plugin:3.3:format-code failed: One of setGitDir or setWorkTree must be called. -> [Help 1]

Added the PR to skip this in proxy/pom.xml while doing mvn install. 
 `mvn -f proxy clean install -DskipTests -DskipFormatCode` skips the format code for a released tarball.
 
 