### PR TITLE
deosu/monit 31993: add fluentBit support

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -405,7 +405,7 @@
     <dependency>
       <groupId>com.wavefront</groupId>
       <artifactId>java-lib</artifactId>
-      <version>2022-10.1</version>
+      <version>2022-11.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/proxy/src/main/java/com/wavefront/agent/formatter/DataFormat.java
+++ b/proxy/src/main/java/com/wavefront/agent/formatter/DataFormat.java
@@ -17,7 +17,8 @@ public enum DataFormat {
   EVENT,
   SPAN,
   SPAN_LOG,
-  LOGS_JSON_ARR;
+  LOGS_JSON_ARR,
+  LOGS_JSON_LINES;
 
   public static DataFormat autodetect(final String input) {
     if (input.length() < 2) return DEFAULT;
@@ -60,6 +61,8 @@ public enum DataFormat {
         return DataFormat.SPAN_LOG;
       case Constants.PUSH_FORMAT_LOGS_JSON_ARR:
         return DataFormat.LOGS_JSON_ARR;
+      case Constants.PUSH_FORMAT_LOGS_JSON_LINES:
+        return DataFormat.LOGS_JSON_LINES;
       default:
         return null;
     }

--- a/proxy/src/main/java/com/wavefront/agent/listeners/AbstractLineDelimitedHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/AbstractLineDelimitedHandler.java
@@ -164,7 +164,7 @@ public abstract class AbstractLineDelimitedHandler extends AbstractPortUnificati
 
   protected void processBatchMetrics(
       final ChannelHandlerContext ctx, final FullHttpRequest request, @Nullable DataFormat format) {
-    if (format == LOGS_JSON_ARR) {
+    if (format == LOGS_JSON_ARR || format == LOGS_JSON_LINES) {
       receivedLogsBatches.get().update(request.content().toString(CharsetUtil.UTF_8).length());
     }
   }

--- a/proxy/src/main/java/com/wavefront/agent/listeners/WavefrontPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/WavefrontPortUnificationHandler.java
@@ -336,6 +336,7 @@ public class WavefrontPortUnificationHandler extends AbstractLineDelimitedHandle
             message, histogramDecoder, histogramHandler, preprocessorSupplier, ctx, "histogram");
         return;
       case LOGS_JSON_ARR:
+      case LOGS_JSON_LINES:
         if (isFeatureDisabled(logsDisabled, LOGS_DISABLED, discardedLogs.get())) return;
         ReportableEntityHandler<ReportLog, ReportLog> logHandler = logHandlerSupplier.get();
         if (logHandler == null || logDecoder == null) {

--- a/proxy/src/main/java/com/wavefront/agent/listeners/WavefrontPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/WavefrontPortUnificationHandler.java
@@ -4,6 +4,7 @@ import static com.wavefront.agent.channel.ChannelUtils.formatErrorMessage;
 import static com.wavefront.agent.channel.ChannelUtils.writeHttpResponse;
 import static com.wavefront.agent.formatter.DataFormat.HISTOGRAM;
 import static com.wavefront.agent.formatter.DataFormat.LOGS_JSON_ARR;
+import static com.wavefront.agent.formatter.DataFormat.LOGS_JSON_LINES;
 import static com.wavefront.agent.formatter.DataFormat.SPAN;
 import static com.wavefront.agent.formatter.DataFormat.SPAN_LOG;
 import static com.wavefront.agent.listeners.FeatureCheckUtils.HISTO_DISABLED;
@@ -226,7 +227,7 @@ public class WavefrontPortUnificationHandler extends AbstractLineDelimitedHandle
       receivedSpansTotal.get().inc(discardedSpans.get().count());
       writeHttpResponse(ctx, HttpResponseStatus.FORBIDDEN, out, request);
       return;
-    } else if (format == LOGS_JSON_ARR
+    } else if ((format == LOGS_JSON_ARR || format == LOGS_JSON_LINES)
         && isFeatureDisabled(logsDisabled, LOGS_DISABLED, discardedLogs.get(), out, request)) {
       receivedLogsTotal.get().inc(discardedLogs.get().count());
       writeHttpResponse(ctx, HttpResponseStatus.FORBIDDEN, out, request);


### PR DESCRIPTION
Add support for new format `logs_json_lines`.
Update handling of HTTP messages to process JsonLines along with JsonArray.
Add an integration test to check JsonLines logs processing.
Update discarded Http-messages counts while ingesting `fluentBit` logs.
Update receivedLogsBatches count for `fluentBit` logs batches.