### PR TITLE
Add 5 second timeout for PushAgent tests

### DIFF
--- a/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
@@ -91,6 +91,7 @@ import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMock;
 import org.junit.*;
+import org.junit.rules.Timeout;
 import wavefront.report.Annotation;
 import wavefront.report.Histogram;
 import wavefront.report.HistogramType;
@@ -167,6 +168,8 @@ public class PushAgentTest {
           mockTraceSpanLogsHandler,
           mockEventHandler);
   private HttpClient mockHttpClient = EasyMock.createMock(HttpClient.class);
+
+  @Rule public Timeout globalTimeout = Timeout.seconds(5);
 
   @BeforeClass
   public static void init() throws Exception {


### PR DESCRIPTION
When playing with the `tlsPorts` functionality and commenting out parts of the implementation, I found that `mvn clean test` would seem to hang forever. I tracked it down to `PushAgentTest`. This PR adds a 5 second timeout for each test in that class, so that the test suite continues running instead of hanging.

Output when there are timeout failures looks like:

```
[ERROR] Errors:
[ERROR] com.wavefront.agent.PushAgentTest.testSecureAll
[ERROR]   Run 1: PushAgentTest.testSecureAll:250 » TestTimedOut test timed out after 5 seconds
[ERROR]   Run 2: PushAgentTest.testSecureAll:250 » TestTimedOut test timed out after 5 seconds
[ERROR]   Run 3: PushAgentTest.testSecureAll:250 » TestTimedOut test timed out after 5 seconds
[ERROR]   Run 4: PushAgentTest.testSecureAll:250 » TestTimedOut test timed out after 5 seconds
[INFO]
[ERROR] com.wavefront.agent.PushAgentTest.testWavefrontUnifiedPortHandlerGzippedPlaintextStream
[ERROR]   Run 1: PushAgentTest.testWavefrontUnifiedPortHandlerGzippedPlaintextStream:470 » TestTimedOut
[ERROR]   Run 2: PushAgentTest.testWavefrontUnifiedPortHandlerGzippedPlaintextStream:470 » TestTimedOut
[ERROR]   Run 3: PushAgentTest.testWavefrontUnifiedPortHandlerGzippedPlaintextStream:470 » TestTimedOut
[ERROR]   Run 4: PushAgentTest.testWavefrontUnifiedPortHandlerGzippedPlaintextStream:470 » TestTimedOut
[INFO]
[ERROR] com.wavefront.agent.PushAgentTest.testWavefrontUnifiedPortHandlerHttpGzipped
[ERROR]   Run 1: PushAgentTest.testWavefrontUnifiedPortHandlerHttpGzipped:693 » TestTimedOut te...
[ERROR]   Run 2: PushAgentTest.testWavefrontUnifiedPortHandlerHttpGzipped:693 » TestTimedOut te...
[ERROR]   Run 3: PushAgentTest.testWavefrontUnifiedPortHandlerHttpGzipped:693 » TestTimedOut te...
[ERROR]   Run 4: PushAgentTest.testWavefrontUnifiedPortHandlerHttpGzipped:693 » TestTimedOut te...
[INFO]
[ERROR] com.wavefront.agent.PushAgentTest.testWavefrontUnifiedPortHandlerPlaintextOverHttp
[ERROR]   Run 1: PushAgentTest.testWavefrontUnifiedPortHandlerPlaintextOverHttp:588 » TestTimedOut
[ERROR]   Run 2: PushAgentTest.testWavefrontUnifiedPortHandlerPlaintextOverHttp:588 » TestTimedOut
[ERROR]   Run 3: PushAgentTest.testWavefrontUnifiedPortHandlerPlaintextOverHttp:588 » TestTimedOut
[ERROR]   Run 4: PushAgentTest.testWavefrontUnifiedPortHandlerPlaintextOverHttp:588 » TestTimedOut
[INFO]
[ERROR] com.wavefront.agent.PushAgentTest.testWavefrontUnifiedPortHandlerPlaintextUncompressed
[ERROR]   Run 1: PushAgentTest.testWavefrontUnifiedPortHandlerPlaintextUncompressed:375 » TestTimedOut
[ERROR]   Run 2: PushAgentTest.testWavefrontUnifiedPortHandlerPlaintextUncompressed:375 » TestTimedOut
[ERROR]   Run 3: PushAgentTest.testWavefrontUnifiedPortHandlerPlaintextUncompressed:375 » TestTimedOut
[ERROR]   Run 4: PushAgentTest.testWavefrontUnifiedPortHandlerPlaintextUncompressed:375 » TestTimedOut
[INFO]
[INFO]
[ERROR] Tests run: 367, Failures: 0, Errors: 5, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:02 min
[INFO] Finished at: 2022-12-13T10:48:32-07:00
[INFO] ------------------------------------------------------------------------
```