### PR TITLE
MONIT 32316 process cloud watch logs

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -386,7 +386,7 @@
     <dependency>
       <groupId>com.wavefront</groupId>
       <artifactId>java-lib</artifactId>
-      <version>2023-01.1</version>
+      <version>2023-01.31</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -386,7 +386,7 @@
     <dependency>
       <groupId>com.wavefront</groupId>
       <artifactId>java-lib</artifactId>
-      <version>2022-11.1</version>
+      <version>2023-01.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -386,7 +386,7 @@
     <dependency>
       <groupId>com.wavefront</groupId>
       <artifactId>java-lib</artifactId>
-      <version>2023-01.31</version>
+      <version>2023-01.31-alpha-3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/proxy/src/main/java/com/wavefront/agent/formatter/DataFormat.java
+++ b/proxy/src/main/java/com/wavefront/agent/formatter/DataFormat.java
@@ -64,7 +64,7 @@ public enum DataFormat {
         return DataFormat.LOGS_JSON_ARR;
       case Constants.PUSH_FORMAT_LOGS_JSON_LINES:
         return DataFormat.LOGS_JSON_LINES;
-      case "logs_json_cloudwatch":
+      case Constants.PUSH_FORMAT_LOGS_JSON_CLOUDWATCH:
         return DataFormat.LOGS_JSON_CLOUDWATCH;
       default:
         return null;

--- a/proxy/src/main/java/com/wavefront/agent/formatter/DataFormat.java
+++ b/proxy/src/main/java/com/wavefront/agent/formatter/DataFormat.java
@@ -18,7 +18,8 @@ public enum DataFormat {
   SPAN,
   SPAN_LOG,
   LOGS_JSON_ARR,
-  LOGS_JSON_LINES;
+  LOGS_JSON_LINES,
+  LOGS_JSON_CLOUDWATCH;
 
   public static DataFormat autodetect(final String input) {
     if (input.length() < 2) return DEFAULT;
@@ -63,6 +64,8 @@ public enum DataFormat {
         return DataFormat.LOGS_JSON_ARR;
       case Constants.PUSH_FORMAT_LOGS_JSON_LINES:
         return DataFormat.LOGS_JSON_LINES;
+      case "logs_json_cloudwatch":
+        return DataFormat.LOGS_JSON_CLOUDWATCH;
       default:
         return null;
     }

--- a/proxy/src/main/java/com/wavefront/agent/listeners/AbstractLineDelimitedHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/AbstractLineDelimitedHandler.java
@@ -3,6 +3,7 @@ package com.wavefront.agent.listeners;
 import static com.wavefront.agent.channel.ChannelUtils.errorMessageWithRootCause;
 import static com.wavefront.agent.channel.ChannelUtils.writeHttpResponse;
 import static com.wavefront.agent.formatter.DataFormat.LOGS_JSON_ARR;
+import static com.wavefront.agent.formatter.DataFormat.LOGS_JSON_CLOUDWATCH;
 import static com.wavefront.agent.formatter.DataFormat.LOGS_JSON_LINES;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -44,6 +45,7 @@ import org.jetbrains.annotations.NotNull;
 public abstract class AbstractLineDelimitedHandler extends AbstractPortUnificationHandler {
 
   public static final ObjectMapper JSON_PARSER = new ObjectMapper();
+  public static final String LOG_EVENTS_KEY = "logEvents";
   private final Supplier<Histogram> receivedLogsBatches;
 
   /**
@@ -77,6 +79,8 @@ public abstract class AbstractLineDelimitedHandler extends AbstractPortUnificati
         lines = extractLogsWithJsonArrayFormat(request);
       } else if (format == LOGS_JSON_LINES) {
         lines = extractLogsWithJsonLinesFormat(request);
+      } else if (format == LOGS_JSON_CLOUDWATCH) {
+        lines = extractLogsWithJsonCloudwatchFormat(request);
       } else {
         lines = extractLogsWithDefaultFormat(request);
       }
@@ -98,6 +102,33 @@ public abstract class AbstractLineDelimitedHandler extends AbstractPortUnificati
         .split(request.content().toString(CharsetUtil.UTF_8));
   }
 
+  private Iterable<String> extractLogsWithJsonCloudwatchFormat(FullHttpRequest request)
+      throws IOException {
+    JsonNode node =
+        JSON_PARSER
+            .readerFor(JsonNode.class)
+            .readValue(request.content().toString(CharsetUtil.UTF_8));
+
+    return extractLogsFromArray(node.get(LOG_EVENTS_KEY).toString());
+  }
+
+  @NotNull
+  private static List<String> extractLogsFromArray(String content) throws JsonProcessingException {
+    return JSON_PARSER
+        .readValue(content, new TypeReference<List<Map<String, Object>>>() {})
+        .stream()
+        .map(
+            json -> {
+              try {
+                return JSON_PARSER.writeValueAsString(json);
+              } catch (JsonProcessingException e) {
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
   private Iterable<String> extractLogsWithJsonLinesFormat(FullHttpRequest request)
       throws IOException {
     List<String> lines = new ArrayList<>();
@@ -114,21 +145,7 @@ public abstract class AbstractLineDelimitedHandler extends AbstractPortUnificati
   @NotNull
   private static Iterable<String> extractLogsWithJsonArrayFormat(FullHttpRequest request)
       throws IOException {
-    return JSON_PARSER
-        .readValue(
-            request.content().toString(CharsetUtil.UTF_8),
-            new TypeReference<List<Map<String, Object>>>() {})
-        .stream()
-        .map(
-            json -> {
-              try {
-                return JSON_PARSER.writeValueAsString(json);
-              } catch (JsonProcessingException e) {
-                return null;
-              }
-            })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+    return extractLogsFromArray(request.content().toString(CharsetUtil.UTF_8));
   }
 
   /**
@@ -164,7 +181,7 @@ public abstract class AbstractLineDelimitedHandler extends AbstractPortUnificati
 
   protected void processBatchMetrics(
       final ChannelHandlerContext ctx, final FullHttpRequest request, @Nullable DataFormat format) {
-    if (format == LOGS_JSON_ARR || format == LOGS_JSON_LINES) {
+    if (format == LOGS_JSON_ARR || format == LOGS_JSON_LINES || format == LOGS_JSON_CLOUDWATCH) {
       receivedLogsBatches.get().update(request.content().toString(CharsetUtil.UTF_8).length());
     }
   }

--- a/proxy/src/main/java/com/wavefront/agent/listeners/WavefrontPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/WavefrontPortUnificationHandler.java
@@ -4,6 +4,7 @@ import static com.wavefront.agent.channel.ChannelUtils.formatErrorMessage;
 import static com.wavefront.agent.channel.ChannelUtils.writeHttpResponse;
 import static com.wavefront.agent.formatter.DataFormat.HISTOGRAM;
 import static com.wavefront.agent.formatter.DataFormat.LOGS_JSON_ARR;
+import static com.wavefront.agent.formatter.DataFormat.LOGS_JSON_CLOUDWATCH;
 import static com.wavefront.agent.formatter.DataFormat.LOGS_JSON_LINES;
 import static com.wavefront.agent.formatter.DataFormat.SPAN;
 import static com.wavefront.agent.formatter.DataFormat.SPAN_LOG;
@@ -227,7 +228,9 @@ public class WavefrontPortUnificationHandler extends AbstractLineDelimitedHandle
       receivedSpansTotal.get().inc(discardedSpans.get().count());
       writeHttpResponse(ctx, HttpResponseStatus.FORBIDDEN, out, request);
       return;
-    } else if ((format == LOGS_JSON_ARR || format == LOGS_JSON_LINES)
+    } else if ((format == LOGS_JSON_ARR
+            || format == LOGS_JSON_LINES
+            || format == LOGS_JSON_CLOUDWATCH)
         && isFeatureDisabled(logsDisabled, LOGS_DISABLED, discardedLogs.get(), out, request)) {
       receivedLogsTotal.get().inc(discardedLogs.get().count());
       writeHttpResponse(ctx, HttpResponseStatus.FORBIDDEN, out, request);
@@ -338,6 +341,7 @@ public class WavefrontPortUnificationHandler extends AbstractLineDelimitedHandle
         return;
       case LOGS_JSON_ARR:
       case LOGS_JSON_LINES:
+      case LOGS_JSON_CLOUDWATCH:
         if (isFeatureDisabled(logsDisabled, LOGS_DISABLED, discardedLogs.get())) return;
         ReportableEntityHandler<ReportLog, ReportLog> logHandler = logHandlerSupplier.get();
         if (logHandler == null || logDecoder == null) {

--- a/proxy/src/test/java/com/wavefront/agent/HttpEndToEndTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/HttpEndToEndTest.java
@@ -808,6 +808,57 @@ public class HttpEndToEndTest {
     assertTrueWithTimeout(50, gotLog::get);
   }
 
+  @Test
+  public void testEndToEndLogCloudwatch() throws Exception {
+    long time = Clock.now() / 1000;
+    proxyPort = findAvailablePort(2898);
+    String buffer = File.createTempFile("proxyTestBuffer", null).getPath();
+    proxy = new PushAgent();
+    proxy.proxyConfig.server = "http://localhost:" + backendPort + "/api/";
+    proxy.proxyConfig.flushThreads = 1;
+    proxy.proxyConfig.pushListenerPorts = String.valueOf(proxyPort);
+    proxy.proxyConfig.bufferFile = buffer;
+    proxy.proxyConfig.pushRateLimitLogs = 1024;
+    proxy.proxyConfig.pushFlushIntervalLogs = 50;
+
+    proxy.start(new String[] {});
+    waitUntilListenerIsOnline(proxyPort);
+    if (!(proxy.senderTaskFactory instanceof SenderTaskFactoryImpl)) fail();
+    if (!(proxy.queueingFactory instanceof QueueingFactoryImpl)) fail();
+
+    long timestamp = time * 1000 + 12345;
+    String payload =
+        "{\"someKey\": \"someVal\", "
+            + "\"logEvents\": [{\"source\": \"myHost1\", \"timestamp\": \""
+            + timestamp
+            + "\"}, "
+            + "{\"source\": \"myHost2\", \"timestamp\": \""
+            + timestamp
+            + "\"}]}";
+
+    String expectedLog1 =
+        "[{\"source\":\"myHost1\",\"timestamp\":" + timestamp + ",\"text\":\"\"" + "}]";
+    String expectedLog2 =
+        "[{\"source\":\"myHost2\",\"timestamp\":" + timestamp + ",\"text\":\"\"" + "}]";
+
+    AtomicBoolean gotLog = new AtomicBoolean(false);
+    Set<String> actualLogs = new HashSet<>();
+    server.update(
+        req -> {
+          String content = req.content().toString(CharsetUtil.UTF_8);
+          logger.fine("Content received: " + content);
+          actualLogs.add(content);
+          return makeResponse(HttpResponseStatus.OK, "");
+        });
+    gzippedHttpPost("http://localhost:" + proxyPort + "/?f=" + "logs_json_cloudwatch", payload);
+    HandlerKey key = HandlerKey.of(ReportableEntityType.LOGS, String.valueOf(proxyPort));
+    proxy.senderTaskFactory.flushNow(key);
+    ((QueueingFactoryImpl) proxy.queueingFactory).flushNow(key);
+    assertEquals(2, actualLogs.size());
+    if (actualLogs.contains(expectedLog1) && actualLogs.contains(expectedLog2)) gotLog.set(true);
+    assertTrueWithTimeout(50, gotLog::get);
+  }
+
   private static class WrappingHttpHandler extends AbstractHttpOnlyHandler {
     private final Function<FullHttpRequest, HttpResponse> func;
 


### PR DESCRIPTION
Update the proxy to read logs with a format(logs_json_cloudwatch).
This code change has a dependency on the next java-lib release(which should be released soon). If the latest java-lib release is not `2023-01.1`, then we need to get java-lb changes locally from the feature branch and build the java-lib jar. Then build the proxy jar with the following command. 
`mvn clean install:install-file -Dfile=<path to your java-lib jar> \
   -DgroupId=com.wavefront \
   -DartifactId=java-lib \
   -Dversion=2023-01.1 \
   -Dpackaging=jar`