### PR TITLE
MONIT-34093 - Mitigation for CVE-2022-1471

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -593,6 +593,11 @@
       <artifactId>proto-google-common-protos</artifactId>
       <version>2.0.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.33</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/PreprocessorConfigManager.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/PreprocessorConfigManager.java
@@ -26,6 +26,7 @@ import org.apache.commons.codec.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 /**
  * Parses preprocessor rules (organized by listening port)
@@ -211,7 +212,7 @@ public class PreprocessorConfigManager {
   void loadFromStream(InputStream stream) {
     totalValidRules = 0;
     totalInvalidRules = 0;
-    Yaml yaml = new Yaml();
+    Yaml yaml = new Yaml(new SafeConstructor());
     Map<String, ReportableEntityPreprocessor> portMap = new HashMap<>();
     lockMetricsFilter.clear();
     try {

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRuleV2PredicateTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRuleV2PredicateTest.java
@@ -10,6 +10,7 @@ import java.util.function.Predicate;
 import org.junit.Assert;
 import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import wavefront.report.ReportPoint;
 import wavefront.report.Span;
 
@@ -25,7 +26,7 @@ public class PreprocessorRuleV2PredicateTest {
     InputStream stream =
         PreprocessorRulesTest.class.getResourceAsStream("preprocessor_rules_predicates.yaml");
     PreprocessorConfigManager config = new PreprocessorConfigManager();
-    Yaml yaml = new Yaml();
+    Yaml yaml = new Yaml(new SafeConstructor());
     Map<String, Object> rulesByPort = yaml.load(stream);
     ReportPoint point = null;
     for (String comparisonOp : COMPARISON_OPS) {
@@ -91,7 +92,7 @@ public class PreprocessorRuleV2PredicateTest {
     InputStream stream =
         PreprocessorRulesTest.class.getResourceAsStream("preprocessor_rules_predicates.yaml");
     PreprocessorConfigManager config = new PreprocessorConfigManager();
-    Yaml yaml = new Yaml();
+    Yaml yaml = new Yaml(new SafeConstructor());
     Map<String, Object> rulesByPort = (Map<String, Object>) yaml.load(stream);
     ReportPoint point = null;
     for (String comparisonOp : COMPARISON_OPS) {
@@ -157,7 +158,7 @@ public class PreprocessorRuleV2PredicateTest {
     InputStream stream =
         PreprocessorRulesTest.class.getResourceAsStream("preprocessor_rules_predicates.yaml");
     PreprocessorConfigManager config = new PreprocessorConfigManager();
-    Yaml yaml = new Yaml();
+    Yaml yaml = new Yaml(new SafeConstructor());
     Map<String, Object> rulesByPort = (Map<String, Object>) yaml.load(stream);
     String spanLine =
         "testSpanName source=spanSourceName spanId=4217104a-690d-4927-baff-d9aa779414c2 "
@@ -237,7 +238,7 @@ public class PreprocessorRuleV2PredicateTest {
     InputStream stream =
         PreprocessorRulesTest.class.getResourceAsStream("preprocessor_rules_predicates.yaml");
     PreprocessorConfigManager config = new PreprocessorConfigManager();
-    Yaml yaml = new Yaml();
+    Yaml yaml = new Yaml(new SafeConstructor());
     Map<String, Object> rulesByPort = (Map<String, Object>) yaml.load(stream);
     String spanLine =
         "testSpanName source=spanSourceName spanId=4217104a-690d-4927-baff-d9aa779414c2 "
@@ -317,7 +318,7 @@ public class PreprocessorRuleV2PredicateTest {
     InputStream stream =
         PreprocessorRulesTest.class.getResourceAsStream("preprocessor_rules_predicates.yaml");
     PreprocessorConfigManager config = new PreprocessorConfigManager();
-    Yaml yaml = new Yaml();
+    Yaml yaml = new Yaml(new SafeConstructor());
     Map<String, Object> rulesByPort = yaml.load(stream);
     List<Map<String, Object>> rules =
         (List<Map<String, Object>>) rulesByPort.get("logicalop-reportpoint");
@@ -380,7 +381,7 @@ public class PreprocessorRuleV2PredicateTest {
     InputStream stream =
         PreprocessorRulesTest.class.getResourceAsStream("preprocessor_rules_predicates.yaml");
     PreprocessorConfigManager config = new PreprocessorConfigManager();
-    Yaml yaml = new Yaml();
+    Yaml yaml = new Yaml(new SafeConstructor());
     Map<String, Object> rulesByPort = (Map<String, Object>) yaml.load(stream);
     List<Map<String, Object>> rules = (List<Map<String, Object>>) rulesByPort.get("logicalop-span");
     Assert.assertEquals("Expected rule size :: ", 1, rules.size());


### PR DESCRIPTION
- explicitly add dependency on snakeyaml since we import it directly in the code
- use SafeConstructor form of the Yaml object construction to mitigate CVE-2022-1471