### PR TITLE
MONIT-34093 - Upgrade to snakeyaml 2.0 for CVE-2022-1471

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -593,6 +593,11 @@
       <artifactId>proto-google-common-protos</artifactId>
       <version>2.0.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>2.0</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/proxy/src/test/java/com/wavefront/agent/logsharvesting/LogsIngesterTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/logsharvesting/LogsIngesterTest.java
@@ -1,18 +1,27 @@
 package com.wavefront.agent.logsharvesting;
 
-import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.verify;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 import com.wavefront.agent.PointMatchers;
 import com.wavefront.agent.auth.TokenAuthenticatorBuilder;
 import com.wavefront.agent.channel.NoopHealthCheckManager;
@@ -44,12 +53,14 @@ import org.junit.After;
 import org.junit.Test;
 import org.logstash.beats.Message;
 import org.yaml.snakeyaml.LoaderOptions;
-
 import wavefront.report.Histogram;
 import wavefront.report.ReportPoint;
 
 /** @author Mori Bellamy (mori@wavefront.com) */
 public class LogsIngesterTest {
+  private final AtomicLong now;
+  private final AtomicLong nanos;
+  private final ObjectMapper objectMapper;
   private LogsIngestionConfig logsIngestionConfig;
   private LogsIngester logsIngesterUnderTest;
   private FilebeatIngester filebeatIngesterUnderTest;
@@ -57,9 +68,6 @@ public class LogsIngesterTest {
   private ReportableEntityHandlerFactory mockFactory;
   private ReportableEntityHandler<ReportPoint, String> mockPointHandler;
   private ReportableEntityHandler<ReportPoint, String> mockHistogramHandler;
-  private final AtomicLong now;
-  private final AtomicLong nanos;
-  private final ObjectMapper objectMapper;
 
   public LogsIngesterTest() {
     this.now = new AtomicLong((System.currentTimeMillis() / 60000) * 60000);

--- a/proxy/src/test/java/com/wavefront/agent/logsharvesting/LogsIngesterTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/logsharvesting/LogsIngesterTest.java
@@ -5,12 +5,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.contains;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 import com.wavefront.agent.PointMatchers;
 import com.wavefront.agent.auth.TokenAuthenticatorBuilder;
 import com.wavefront.agent.channel.NoopHealthCheckManager;
@@ -41,6 +44,8 @@ import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Test;
 import org.logstash.beats.Message;
+import org.yaml.snakeyaml.LoaderOptions;
+
 import wavefront.report.Histogram;
 import wavefront.report.ReportPoint;
 
@@ -53,9 +58,16 @@ public class LogsIngesterTest {
   private ReportableEntityHandlerFactory mockFactory;
   private ReportableEntityHandler<ReportPoint, String> mockPointHandler;
   private ReportableEntityHandler<ReportPoint, String> mockHistogramHandler;
-  private AtomicLong now = new AtomicLong((System.currentTimeMillis() / 60000) * 60000);
-  private AtomicLong nanos = new AtomicLong(System.nanoTime());
-  private ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+  private AtomicLong now;
+  private AtomicLong nanos;
+  private ObjectMapper objectMapper;
+
+  public LogsIngesterTest() {
+    this.now = new AtomicLong((System.currentTimeMillis() / 60000) * 60000);
+    this.nanos = new AtomicLong(System.nanoTime());
+    YAMLFactoryBuilder factory = new YAMLFactoryBuilder(new YAMLFactory());
+    this.objectMapper = new ObjectMapper(factory.loaderOptions(new LoaderOptions()).build());
+  }
 
   private LogsIngestionConfig parseConfigFile(String configPath) throws IOException {
     File configFile =

--- a/proxy/src/test/java/com/wavefront/agent/logsharvesting/LogsIngesterTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/logsharvesting/LogsIngesterTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.contains;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableList;
@@ -58,9 +57,9 @@ public class LogsIngesterTest {
   private ReportableEntityHandlerFactory mockFactory;
   private ReportableEntityHandler<ReportPoint, String> mockPointHandler;
   private ReportableEntityHandler<ReportPoint, String> mockHistogramHandler;
-  private AtomicLong now;
-  private AtomicLong nanos;
-  private ObjectMapper objectMapper;
+  private final AtomicLong now;
+  private final AtomicLong nanos;
+  private final ObjectMapper objectMapper;
 
   public LogsIngesterTest() {
     this.now = new AtomicLong((System.currentTimeMillis() / 60000) * 60000);


### PR DESCRIPTION
- explicitly add dependency on snakeyaml since we import it directly in the code
- update test to use explict loadOptions on the YamlFactory for the objectmapper