### PR TITLE
Making csp orgId optional by default for the proxy

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/ProxyConfig.java
+++ b/proxy/src/main/java/com/wavefront/agent/ProxyConfig.java
@@ -1461,33 +1461,27 @@ public class ProxyConfig extends ProxyConfigDef {
       @Nonnull final String tenantName) {
 
     final String BAD_CONFIG =
-        "incorrect configuration, one (and only one) of this options are required: `token`, `cspAPIToken` or `cspAppId, cspAppSecret, cspOrgId`"
+        "incorrect configuration, one (and only one) of these options are required: `token`, `cspAPIToken` or `cspAppId, cspAppSecret`"
             + (CENTRAL_TENANT_NAME.equals(tenantName) ? "" : " for tenant `" + tenantName + "`");
 
-    boolean isOAuthApp =
-        StringUtils.isNotBlank(appId)
-            || StringUtils.isNotBlank(appSecret)
-            || StringUtils.isNotBlank(cspOrgId);
+    boolean isOAuthApp = StringUtils.isNotBlank(appId) || StringUtils.isNotBlank(appSecret);
     boolean isCSPAPIToken = StringUtils.isNotBlank(cspAPIToken);
     boolean isWFToken = StringUtils.isNotBlank(wfToken);
 
-    long authMethods =
-        Arrays.asList(isOAuthApp, isCSPAPIToken, isWFToken).stream().filter(auth -> auth).count();
-    if (authMethods != 1) {
+    if (Stream.of(isOAuthApp, isCSPAPIToken, isWFToken).filter(auth -> auth).count() != 1) {
       throw new IllegalArgumentException(BAD_CONFIG);
     }
 
     TenantInfo tokenWorker;
     if (isOAuthApp) {
-      if (StringUtils.isNotBlank(appId)
-          && StringUtils.isNotBlank(appSecret)
-          && StringUtils.isNotBlank(cspOrgId)) {
+      if (StringUtils.isNotBlank(appId) && StringUtils.isNotBlank(appSecret)) {
         logger.info(
             "TCSP OAuth server to server app credentials for further authentication. For the server "
                 + server);
         tokenWorker = new TokenWorkerCSP(appId, appSecret, cspOrgId, server);
       } else {
-        throw new IllegalArgumentException(BAD_CONFIG);
+        throw new IllegalArgumentException(
+            "To use server to server oauth, both `cspAppId` and `cspAppSecret` are required.");
       }
     } else if (isCSPAPIToken) {
       logger.info("CSP api token for further authentication. For the server " + server);

--- a/proxy/src/main/java/com/wavefront/agent/TokenWorkerCSP.java
+++ b/proxy/src/main/java/com/wavefront/agent/TokenWorkerCSP.java
@@ -1,7 +1,9 @@
 package com.wavefront.agent;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 
+import com.google.common.base.Strings;
 import com.wavefront.agent.api.APIContainer;
 import com.wavefront.agent.api.CSPAPI;
 import com.wavefront.common.LazySupplier;
@@ -67,16 +69,16 @@ public class TokenWorkerCSP
 
   public TokenWorkerCSP(
       final String appId, final String appSecret, final String orgId, final String wfServer) {
-    this.appId = appId;
-    this.appSecret = appSecret;
+    this.appId = checkNotNull(appId);
+    this.appSecret = checkNotNull(appSecret);
     this.orgId = orgId;
-    this.wfServer = wfServer;
+    this.wfServer = checkNotNull(wfServer);
     proxyAuthMethod = ProxyAuthMethod.CLIENT_CREDENTIALS;
   }
 
   public TokenWorkerCSP(final String token, final String wfServer) {
-    this.token = token;
-    this.wfServer = wfServer;
+    this.token = checkNotNull(token);
+    this.wfServer = checkNotNull(wfServer);
     proxyAuthMethod = ProxyAuthMethod.API_TOKEN;
   }
 
@@ -134,7 +136,12 @@ public class TokenWorkerCSP
             "Basic %s",
             Base64.getEncoder()
                 .encodeToString(String.format("%s:%s", appId, appSecret).getBytes()));
-    return api.getTokenByClientCredentials(auth, "client_credentials", orgId);
+
+    if (Strings.isNullOrEmpty(orgId)) {
+      return api.getTokenByClientCredentials(auth, "client_credentials");
+    }
+
+    return api.getTokenByClientCredentialsWithOrgId(auth, "client_credentials", orgId);
   }
 
   private long processResponse(final Response response) {

--- a/proxy/src/main/java/com/wavefront/agent/api/CSPAPI.java
+++ b/proxy/src/main/java/com/wavefront/agent/api/CSPAPI.java
@@ -16,8 +16,15 @@ public interface CSPAPI {
   @POST
   @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   @Path("csp/gateway/am/api/auth/authorize")
-  Response getTokenByClientCredentials(
+  Response getTokenByClientCredentialsWithOrgId(
       @HeaderParam(HttpHeaders.AUTHORIZATION) final String auth,
       @FormParam("grant_type") final String grantType,
       @FormParam("orgId") final String orgId);
+
+  @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  @Path("csp/gateway/am/api/auth/authorize")
+  Response getTokenByClientCredentials(
+      @HeaderParam(HttpHeaders.AUTHORIZATION) final String auth,
+      @FormParam("grant_type") final String grantType);
 }

--- a/proxy/src/test/java/com/wavefront/agent/ProxyConfigTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/ProxyConfigTest.java
@@ -52,17 +52,81 @@ public class ProxyConfigTest {
           "--token", UUID.randomUUID().toString(),
           "--cspAppId", UUID.randomUUID().toString()
         };
+    assertThrows(IllegalArgumentException.class, () -> new ProxyConfig().parseArguments(args, ""));
 
-    ProxyConfig cfg = new ProxyConfig();
-    assertThrows(IllegalArgumentException.class, () -> cfg.parseArguments(args, ""));
+    String[] args2 =
+        new String[] {
+          "--token", UUID.randomUUID().toString(),
+          "--cspAppSecret", UUID.randomUUID().toString()
+        };
+    assertThrows(IllegalArgumentException.class, () -> new ProxyConfig().parseArguments(args2, ""));
+
+    String[] args3 =
+        new String[] {
+          "--token", UUID.randomUUID().toString(),
+          "--cspAppId", UUID.randomUUID().toString(),
+          "--cspAppSecret", UUID.randomUUID().toString()
+        };
+    assertThrows(IllegalArgumentException.class, () -> new ProxyConfig().parseArguments(args3, ""));
+
+    String[] args4 =
+        new String[] {
+          "--cspAPIToken", UUID.randomUUID().toString(),
+          "--cspAppId", UUID.randomUUID().toString(),
+          "--cspAppSecret", UUID.randomUUID().toString()
+        };
+
+    assertThrows(IllegalArgumentException.class, () -> new ProxyConfig().parseArguments(args4, ""));
+
+    String[] args5 =
+        new String[] {
+          "--token", UUID.randomUUID().toString(),
+          "--cspAPIToken", UUID.randomUUID().toString()
+        };
+    assertThrows(IllegalArgumentException.class, () -> new ProxyConfig().parseArguments(args5, ""));
   }
 
   @Test
   public void testBadCSPOAuthConfig() {
     String[] args = new String[] {"--cspAppId", UUID.randomUUID().toString()};
+    assertThrows(IllegalArgumentException.class, () -> new ProxyConfig().parseArguments(args, ""));
 
-    ProxyConfig cfg = new ProxyConfig();
-    assertThrows(IllegalArgumentException.class, () -> cfg.parseArguments(args, ""));
+    String[] args2 = new String[] {"--cspAppSecret", UUID.randomUUID().toString()};
+    assertThrows(IllegalArgumentException.class, () -> new ProxyConfig().parseArguments(args2, ""));
+
+    String[] args3 =
+        new String[] {
+          "--token", UUID.randomUUID().toString(),
+          "--cspAppId", UUID.randomUUID().toString(),
+          "--cspAppSecret", UUID.randomUUID().toString()
+        };
+
+    assertThrows(IllegalArgumentException.class, () -> new ProxyConfig().parseArguments(args3, ""));
+  }
+
+  @Test
+  public void testGoodCSPOAuthConfig() {
+    String[] args =
+        new String[] {
+          "--cspAppId", UUID.randomUUID().toString(),
+          "--cspAppSecret", UUID.randomUUID().toString()
+        };
+
+    assertTrue(new ProxyConfig().parseArguments(args, ""));
+  }
+
+  @Test
+  public void testGoodCSPUserConfig() {
+    String[] args = new String[] {"--cspAPIToken", UUID.randomUUID().toString()};
+
+    assertTrue(new ProxyConfig().parseArguments(args, ""));
+  }
+
+  @Test
+  public void testGoodWfTokenConfig() {
+    String[] args = new String[] {"--token", UUID.randomUUID().toString()};
+
+    assertTrue(new ProxyConfig().parseArguments(args, ""));
   }
 
   @Test


### PR DESCRIPTION
Making csp orgId optional by default. Added tests with this functionality. Fixed a couple of typos.