### PR TITLE
Fix log parsing

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/channel/ChannelUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/channel/ChannelUtils.java
@@ -171,13 +171,11 @@ public abstract class ChannelUtils {
   public static String errorMessageWithRootCause(@Nonnull final Throwable e) {
     StringBuilder msg = new StringBuilder();
     final Throwable rootCause = Throwables.getRootCause(e);
-    msg.append("reason: \"");
+    msg.append("reason: ");
     msg.append(e.getMessage());
-    msg.append("\"");
     if (rootCause != null && rootCause != e && rootCause.getMessage() != null) {
-      msg.append(", root cause: \"");
+      msg.append(", root cause: ");
       msg.append(rootCause.getMessage());
-      msg.append("\"");
     }
     return msg.toString();
   }


### PR DESCRIPTION
by injecting extra double quotes here it break json logging and causes errors like this in fluentd:
```
pattern not matched message="{\"timestamp\":\"2023-10-28T14:01:56.949Z\",\"logger\":\"com.wavefront.agent.listeners.AbstractPortUnificationHandler\",\"region\":\"region-x\",\"hostname\":\"xxx-xxxx-xxxx\",\"service\":\"vmc-wavefront-proxy\",\"app_id\":\"vmc-wavefront-proxy\",\"commit\":\"\",\"build\":\"0.1.0-20231004-252-5ca6a9a\",\"level\":\"WARN\",\"thread\":\"epollEventLoopGroup-17-7\",\"marker\":\"\",\"exception\":\"\",\"message\":\"Received line is too long, consider increasing pushListenerMaxReceivedLength; remote: x.x.x.x [30000]; reason: \"frame length (18463928) exceeds the allowed maximum (1048576)\"\",\"mdc\":\"{}\",\"component\":\"\",\"sub_component\":\"\",\"sddc_id\":\"\",\"org_id\":\"\",\"op_id\":\"\"}"
```

and from the CLI the log looks like this with extra double quotes:
```
2023-10-28 12:02:37,176 WARN  [AbstractPortUnificationHandler:logWarning] Received line is too long, consider increasing pushListenerMaxReceivedLength; remote: x.x.x.x [30000]; reason: "frame length (18468978) exceeds the allowed maximum (1048576)"
```