### PR TITLE
WFESO-6721: update ruby version to 3.0

### DIFF
--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -1,6 +1,6 @@
 # Create a docker VM for building the wavefront proxy agent .deb and .rpm
 # packages.
-FROM ruby:2.7
+FROM ruby:3.0
 
 RUN gem install fpm
 RUN gem install package_cloud


### PR DESCRIPTION
We need to update ruby version to 3.0 to resolve this error shown in our build:

```13:46:28 #5 25.13 ERROR:  Error installing fpm:
13:46:28 #5 25.13 	The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again
13:46:28 #5 25.13 	dotenv requires Ruby version >= 3.0. The current ruby version is 2.7.8.225.
13:46:28 #5 25.46 Successfully installed stud-0.0.23
13:46:28 #5 ERROR: process "/bin/sh -c gem install fpm" did not complete successfully: exit code: 1
13:46:28 ------
13:46:28  > [2/5] RUN gem install fpm:
13:46:28 #5 25.13 ERROR:  Error installing fpm:
13:46:28 #5 25.13 	The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again
13:46:28 #5 25.13 	dotenv requires Ruby version >= 3.0. The current ruby version is 2.7.8.225.
13:46:28 #5 25.46 Successfully installed stud-0.0.23
13:46:28 ------
13:46:28 Dockerfile:5
13:46:28 --------------------
13:46:28    3 |     FROM ruby:2.7
13:46:28    4 |     
13:46:28    5 | >>> RUN gem install fpm
13:46:28    6 |     RUN gem install package_cloud
13:46:28    7 |     RUN apt-get update
13:46:28 --------------------
13:46:28 ERROR: failed to solve: process "/bin/sh -c gem install fpm" did not complete successfully: exit code: 1```